### PR TITLE
REPO-2514 / MNT-17918: Workflow API: Update Process Variable Rest API…

### DIFF
--- a/src/main/java/org/alfresco/rest/workflow/api/impl/ProcessesImpl.java
+++ b/src/main/java/org/alfresco/rest/workflow/api/impl/ProcessesImpl.java
@@ -958,7 +958,7 @@ public class ProcessesImpl extends WorkflowRestImpl implements Processes
             if (nodeService.exists(initiator))
             {
 
-                actualValue = getNodeConverter().convertNode((NodeRef) initiator);
+                actualValue = getNodeConverter().convertNode(initiator);
 
                 // Also update the initiator home reference, if one exists
                 NodeRef initiatorHome = (NodeRef) nodeService.getProperty(initiator, ContentModel.PROP_HOMEFOLDER);

--- a/src/main/java/org/alfresco/rest/workflow/api/impl/ProcessesImpl.java
+++ b/src/main/java/org/alfresco/rest/workflow/api/impl/ProcessesImpl.java
@@ -69,6 +69,7 @@ import org.alfresco.repo.workflow.WorkflowPropertyHandlerRegistry;
 import org.alfresco.repo.workflow.WorkflowQNameConverter;
 import org.alfresco.repo.workflow.activiti.ActivitiConstants;
 import org.alfresco.repo.workflow.activiti.ActivitiNodeConverter;
+import org.alfresco.repo.workflow.activiti.ActivitiScriptNode;
 import org.alfresco.repo.workflow.activiti.ActivitiUtil;
 import org.alfresco.repo.workflow.activiti.properties.ActivitiPropertyConverter;
 import org.alfresco.rest.antlr.WhereClauseParser;
@@ -949,6 +950,31 @@ public class ProcessesImpl extends WorkflowRestImpl implements Processes
             // fix for different ISO 8601 Date format classes in Alfresco (org.alfresco.util and Spring Surf)
             actualValue = ISO8601DateFormat.parse((String) variable.getValue());
         }
+        else if (variable.getName().equals(WorkflowConstants.PROP_INITIATOR))
+        {
+            // update the initiator if exists
+            NodeRef initiator = getNodeRef((String) variable.getValue());
+
+            if (nodeService.exists(initiator))
+            {
+
+                actualValue = getNodeConverter().convertNode((NodeRef) initiator);
+
+                // Also update the initiator home reference, if one exists
+                NodeRef initiatorHome = (NodeRef) nodeService.getProperty(initiator, ContentModel.PROP_HOMEFOLDER);
+                if (initiatorHome != null)
+                {
+                    Variable initiatorHomeVar = new Variable();
+                    initiatorHomeVar.setName(WorkflowConstants.PROP_INITIATOR_HOME);
+                    initiatorHomeVar.setValue(initiatorHome);
+                    updateVariableInProcess(processId, processDefinitionId, initiatorHomeVar);
+                }
+            }
+            else
+            {
+                throw new InvalidArgumentException("Variable value should be a valid person NodeRef.");
+            }
+        }
         else
         {
             if (context.getAssociationDefinition(variable.getName()) != null)
@@ -961,10 +987,20 @@ public class ProcessesImpl extends WorkflowRestImpl implements Processes
                 actualValue = DefaultTypeConverter.INSTANCE.convert(dataTypeDefinition, variable.getValue());
             }
         }
-        variable.setValue(actualValue);
-        
+
         activitiProcessEngine.getRuntimeService().setVariable(processId, variable.getName(), actualValue);
-        
+
+        // Set variable value before returning
+        // Variable value needs to be of type NodeRef
+        if (actualValue instanceof ActivitiScriptNode)
+        {
+            variable.setValue(((ActivitiScriptNode) actualValue).getNodeRef());
+        }
+        else
+        {
+            variable.setValue(actualValue);
+        }
+
         // Set actual used type before returning
         variable.setType(dataTypeDefinition.getName().toPrefixString(namespaceService));
         return variable;

--- a/src/main/java/org/alfresco/rest/workflow/api/impl/WorkflowRestImpl.java
+++ b/src/main/java/org/alfresco/rest/workflow/api/impl/WorkflowRestImpl.java
@@ -512,14 +512,17 @@ public class WorkflowRestImpl
                 throw new PermissionDeniedException("Process is running in another tenant");
             }
         }
-        
-        ActivitiScriptNode initiator = (ActivitiScriptNode) variableMap.get(WorkflowConstants.PROP_INITIATOR);
-        if (initiator != null && AuthenticationUtil.getRunAsUser().equals(initiator.getNodeRef().getId()))
+
+        //MNT-17918 - required for initiator variable already updated as NodeRef type
+        Object initiator = variableMap.get(WorkflowConstants.PROP_INITIATOR);
+        String nodeId = ((initiator instanceof ActivitiScriptNode) ? ((ActivitiScriptNode) initiator).getNodeRef().getId() : ((NodeRef) initiator).getId());
+
+        if (initiator != null && AuthenticationUtil.getRunAsUser().equals(nodeId))
         {
             // user is allowed
             return variableInstances;
         }
-        
+
         String username = AuthenticationUtil.getRunAsUser();
         if (authorityService.isAdminAuthority(username)) 
         {


### PR DESCRIPTION
… fails on updating "initiator":

  - fixed by converting the initiator actual value to a ActivitiScriptNode instead of NodeRef. Still, the value passed in the response must be of type NodeRef
  - added a check in WorkflowRestImpl for cases where customers already updated "initiator" process variable with type NodeRef
  - added a Junit that checks also the "initiator" value after it is set using PUT request