### PR TITLE
REPO-2897: ALF-21944: membership.delete.js - wrong exception variable…

### DIFF
--- a/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/membership/membership.delete.js
+++ b/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/membership/membership.delete.js
@@ -27,7 +27,7 @@ function main()
       {
          status.setCode(status.STATUS_INTERNAL_SERVER_ERROR, msg);
       }
-      else throw error;
+      else throw e;
 	}
 }
 


### PR DESCRIPTION
… name in catch block