### PR TITLE
Fix     REPO-1253  Community: ALF-21749: Manage Sites page broken when users without a surname are synchronized from LDAP

### DIFF
--- a/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/site-admin-sites.get.json.ftl
+++ b/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/site-admin-sites.get.json.ftl
@@ -17,7 +17,7 @@
 	                        "entry" : {
 	                            "userName" : "${manager.userName}",
 	                            "firstName" : "${manager.firstName}",
-	                            "lastName" : "${manager.lastName}"
+	                            "lastName" : "${manager.lastName!""}"
 	                        }
 	                    }<#if manager_has_next>,</#if>
 	                     </#list>

--- a/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/site-admin-sites.get.json.ftl
+++ b/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/site-admin-sites.get.json.ftl
@@ -15,8 +15,8 @@
 	                     <#list item.members as manager>
 	                    {
 	                        "entry" : {
-	                            "userName" : "${manager.userName}",
-	                            "firstName" : "${manager.firstName}",
+	                            "userName" : "${manager.userName!""}",
+	                            "firstName" : "${manager.firstName!""}",
 	                            "lastName" : "${manager.lastName!""}"
 	                        }
 	                    }<#if manager_has_next>,</#if>


### PR DESCRIPTION
To fix the issue, below code was adjusted in the file: `src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/repository/site/site-admin-sites.get.json.ftl`
```
 	                     <#list item.members as manager>
	                    {
	                        "entry" : {
	                            "userName" : "${manager.userName!""}",
	                            "firstName" : "${manager.firstName!""}",
	                            "lastName" : "${manager.lastName!""}"
	                        }
	                    }<#if manager_has_next>,</#if>
	                     </#list>
```