### PR TITLE
REPO-2827: fixed favourite folders/files description field

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -600,7 +600,7 @@ public class NodesImpl implements Nodes
     {
         node.setGuid(nodeRef);
         node.setTitle((String)properties.get(ContentModel.PROP_TITLE));
-        node.setDescription((String)properties.get(ContentModel.PROP_TITLE));
+        node.setDescription((String)properties.get(ContentModel.PROP_DESCRIPTION));
         node.setModifiedBy((String)properties.get(ContentModel.PROP_MODIFIER));
         node.setCreatedBy((String)properties.get(ContentModel.PROP_CREATOR));
     }

--- a/src/test/java/org/alfresco/rest/api/tests/TestFavourites.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestFavourites.java
@@ -1842,6 +1842,10 @@ public class TestFavourites extends AbstractBaseApiTest
         file1Favourite = favouritesProxy.createFavourite(person12Id, file1Favourite, includePath);
         FavouriteNode node = ((FileFavouriteTarget) file1Favourite.getTarget()).getDocument();
         assertPathInfo(node.getPath(), "/Company Home/Sites/" + publicSite.getSiteId() + "/documentLibrary", true);
+        // Check the basic properties (REPO-2827)
+        assertEquals("Test Doc1", node.getName());
+        assertEquals("Test Doc1 Title", node.getTitle());
+        assertEquals("Test Doc1 Description", node.getDescription());
 
 
         // Favourite the doc (Test Doc2)


### PR DESCRIPTION
When listing favourites through the REST API, the folders and files were showing the “title” in the description field rather than the “description”.

Fixed and also added a test.