### PR TITLE
REPO-2979: fixed incorrect test logic while investigating this issue.

### DIFF
--- a/src/test/java/org/alfresco/rest/api/tests/TestCMIS.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestCMIS.java
@@ -490,7 +490,10 @@ public class TestCMIS extends EnterpriseTestApi
         }
         if(expectedMissingSecondaryTypes != null)
         {
-            assertTrue("Expected missing secondary types but at least one is still present: " + secondaryTypes, !secondaryTypes.containsAll(expectedMissingSecondaryTypes));
+            for (String type : expectedMissingSecondaryTypes)
+            {
+                assertFalse("Should not contain secondary type "+type+", but does: "+secondaryTypes, secondaryTypes.contains(type));
+            }
         }
     }
 


### PR DESCRIPTION
I don't believe that the fix for MNT-18546 caused the two test run failures
(logged against REPO-2979) - indeed the test run immediately after the fix
was committed actually passed.

While I was investigating this bug report, I noticed that the test code
in TestCMIS.checkSecondaryTypes has a latent bug in it. We've been ok since
it doesn't exhibit problems when called with expectedMissingSecondaryTypes
having a size of 1, but would fail to pick up a situation where:

   *not all* the aspects that should have been removed were removed.

It would only have picked up the situation where:

   *none* of the aspects that should have been removed were removed.