### PR TITLE
REPO-1154 Using spaces for term-based queries - nodes.

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/QueriesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/QueriesImpl.java
@@ -189,7 +189,12 @@ public class QueriesImpl implements Queries, InitializingBean
                     NodeRef nodeRef = nodes.validateOrLookupNode(rootNodeId, null);
                     query.append("PATH:\"").append(getQNamePath(nodeRef.getId())).append("//*\" AND (");
                 }
-                query.append(term);
+                if (term != null)
+                {
+                    query.append("\"");
+                    query.append(term);
+                    query.append("\"");
+                }
                 if (rootNodeId != null)
                 {
                     query.append(")");

--- a/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
@@ -87,7 +87,7 @@ public class QueriesNodesApiTest extends AbstractSingleNetworkSiteTest
     }
     
     /**
-     * Test basic api for nodes using parameter term with white-spaces
+     * Test basic api for nodes using parameter term with white-spaces.
      *
      * <p>
      * GET:
@@ -103,30 +103,35 @@ public class QueriesNodesApiTest extends AbstractSingleNetworkSiteTest
 
         String myFolderNodeId = getMyNodeId();
 
-        String parentTerm = createFolder(myFolderNodeId, "folder term1").getId();
+        String parentFolder = createFolder(myFolderNodeId, "folder term1").getId();
+        //I use "find123" and "find123 find", the search using second term must return less result
+        //The space must not break the query
         String childTerm = "find" + Math.random();
         String childTermWS = childTerm + " " + "find";
 
         Map<String, String> docProps = new HashMap<>(2);
         docProps.put("cm:title", childTerm);
         docProps.put("cm:description", childTerm);
-        createTextFile(parentTerm, childTerm, childTerm, "UTF-8", docProps);
+        createTextFile(parentFolder, childTerm, childTerm, "UTF-8", docProps);
 
         docProps.put("cm:title", childTermWS);
         docProps.put("cm:description", childTermWS);
-        createTextFile(parentTerm, childTermWS, childTermWS, "UTF-8", docProps);
+        createTextFile(parentFolder, childTermWS, childTermWS, "UTF-8", docProps);
 
         Paging paging = getPaging(0, 100);
         HashMap<String, String> params = new HashMap<>(1);
         params.put(Queries.PARAM_TERM, childTerm);
         HttpResponse response = getAll(URL_QUERIES_LSN, paging, params, 200);
-        List<Node> nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
-        assertEquals(2, nodes.size());
+        List<Node> nodesChildTerm = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
+        //check if the search returns all nodes which contain that query term
+        assertEquals(2, nodesChildTerm.size());
 
         params.put(Queries.PARAM_TERM, childTermWS);
         response = getAll(URL_QUERIES_LSN, paging, params, 200);
-        nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
-        assertEquals(1, nodes.size());
+        List<Node> nodesChildTermWS = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
+        //check if search works for words with space and the space don't break the query
+        assertEquals(1, nodesChildTermWS.size());
+        assertTrue(nodesChildTerm.size() >= nodesChildTermWS.size());
 
     }
 

--- a/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
@@ -86,39 +86,49 @@ public class QueriesNodesApiTest extends AbstractSingleNetworkSiteTest
         return result;
     }
     
+    /**
+     * Test basic api for nodes using parameter term with white-spaces
+     *
+     * <p>
+     * GET:
+     * </p>
+     * {@literal <host>:<port>/alfresco/api/<networkId>/public/alfresco/versions/1/queries/nodes}
+     * 
+     * @throws Exception
+     */
     @Test
-    public void testSearchTermWhiteSpace() throws Exception{
+    public void testSearchTermWhiteSpace() throws Exception
+    {
         setRequestContext(user1);
-        
+
         String myFolderNodeId = getMyNodeId();
 
         String parentTerm = createFolder(myFolderNodeId, "folder term1").getId();
         String childTerm = "find" + Math.random();
-        String childTermWS =  childTerm + " " + "find";
-        
-        Map<String,String> docProps = new HashMap<>(2);
+        String childTermWS = childTerm + " " + "find";
+
+        Map<String, String> docProps = new HashMap<>(2);
         docProps.put("cm:title", childTerm);
         docProps.put("cm:description", childTerm);
         createTextFile(parentTerm, childTerm, childTerm, "UTF-8", docProps);
-        
+
         docProps.put("cm:title", childTermWS);
         docProps.put("cm:description", childTermWS);
         createTextFile(parentTerm, childTermWS, childTermWS, "UTF-8", docProps);
 
         Paging paging = getPaging(0, 100);
-        HashMap<String,String> params = new HashMap<>(1);
-        params.put(Queries.PARAM_TERM,  childTerm);
+        HashMap<String, String> params = new HashMap<>(1);
+        params.put(Queries.PARAM_TERM, childTerm);
         HttpResponse response = getAll(URL_QUERIES_LSN, paging, params, 200);
         List<Node> nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
         assertEquals(2, nodes.size());
-        
-        params.put(Queries.PARAM_TERM,  childTermWS);
+
+        params.put(Queries.PARAM_TERM, childTermWS);
         response = getAll(URL_QUERIES_LSN, paging, params, 200);
         nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
         assertEquals(1, nodes.size());
 
     }
-    
 
     /**
      * Tests basic api for nodes live search - metadata (name, title, description) &/or full text search of file/content

--- a/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
@@ -87,7 +87,7 @@ public class QueriesNodesApiTest extends AbstractSingleNetworkSiteTest
     }
     
     /**
-     * Test basic api for nodes using parameter term with white-spaces.
+     * Test basic api for nodes using parameter term with white-spaces.(REPO-1154)
      *
      * <p>
      * GET:

--- a/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/QueriesNodesApiTest.java
@@ -85,6 +85,40 @@ public class QueriesNodesApiTest extends AbstractSingleNetworkSiteTest
         }
         return result;
     }
+    
+    @Test
+    public void testSearchTermWhiteSpace() throws Exception{
+        setRequestContext(user1);
+        
+        String myFolderNodeId = getMyNodeId();
+
+        String parentTerm = createFolder(myFolderNodeId, "folder term1").getId();
+        String childTerm = "find" + Math.random();
+        String childTermWS =  childTerm + " " + "find";
+        
+        Map<String,String> docProps = new HashMap<>(2);
+        docProps.put("cm:title", childTerm);
+        docProps.put("cm:description", childTerm);
+        createTextFile(parentTerm, childTerm, childTerm, "UTF-8", docProps);
+        
+        docProps.put("cm:title", childTermWS);
+        docProps.put("cm:description", childTermWS);
+        createTextFile(parentTerm, childTermWS, childTermWS, "UTF-8", docProps);
+
+        Paging paging = getPaging(0, 100);
+        HashMap<String,String> params = new HashMap<>(1);
+        params.put(Queries.PARAM_TERM,  childTerm);
+        HttpResponse response = getAll(URL_QUERIES_LSN, paging, params, 200);
+        List<Node> nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
+        assertEquals(2, nodes.size());
+        
+        params.put(Queries.PARAM_TERM,  childTermWS);
+        response = getAll(URL_QUERIES_LSN, paging, params, 200);
+        nodes = RestApiUtil.parseRestApiEntries(response.getJsonResponse(), Node.class);
+        assertEquals(1, nodes.size());
+
+    }
+    
 
     /**
      * Tests basic api for nodes live search - metadata (name, title, description) &/or full text search of file/content


### PR DESCRIPTION
Problem: If you using spaces for the term like find find for the endpoints
GET /queries/nodes the query is valid until the first space. 
Resolution:
I change the query adding the special character \" for term to be seen like text in lucene search.
The other rest requests for /queries/sites and /queries/people have the special character \"  added for term value.