### PR TITLE
Feature/repo 2983 extra path info

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -1071,7 +1071,7 @@ public class NodesImpl implements Nodes
                         Serializable nameProp = nodeService.getProperty(childNodeRef, ContentModel.PROP_NAME);
                         String type = getNodeType(childNodeRef).toPrefixString(namespaceService);
                         Set<QName> aspects = nodeService.getAspects(childNodeRef);
-                        List<String> aspectNames = mapFromNodeAspects(aspects, Collections.emptyList(), Collections.emptyList());
+                        List<String> aspectNames = mapFromNodeAspects(aspects, EXCLUDED_NS, EXCLUDED_ASPECTS);
                         pathElements.add(0, new ElementInfo(childNodeRef.getId(), nameProp.toString(), type, aspectNames));
                     }
                     else

--- a/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -1069,7 +1069,10 @@ public class NodesImpl implements Nodes
                     if (permissionService.hasPermission(childNodeRef, PermissionService.READ) == AccessStatus.ALLOWED)
                     {
                         Serializable nameProp = nodeService.getProperty(childNodeRef, ContentModel.PROP_NAME);
-                        pathElements.add(0, new ElementInfo(childNodeRef.getId(), nameProp.toString()));
+                        String type = getNodeType(childNodeRef).toPrefixString(namespaceService);
+                        Set<QName> aspects = nodeService.getAspects(childNodeRef);
+                        List<String> aspectNames = mapFromNodeAspects(aspects, Collections.emptyList(), Collections.emptyList());
+                        pathElements.add(0, new ElementInfo(childNodeRef.getId(), nameProp.toString(), type, aspectNames));
                     }
                     else
                     {

--- a/src/main/java/org/alfresco/rest/api/model/PathInfo.java
+++ b/src/main/java/org/alfresco/rest/api/model/PathInfo.java
@@ -81,15 +81,19 @@ public class PathInfo
 
         private String id;
         private String name;
+        private String type;
+        private List<String> aspectNames;
 
         public ElementInfo()
         {
         }
-
-        public ElementInfo(String id, String name)
+        
+        public ElementInfo(String id, String name, String type, List<String> aspectNames)
         {
             this.id = id;
             this.name = name;
+            this.type = type;
+            this.aspectNames = aspectNames;
         }
 
         public String getName()
@@ -102,12 +106,24 @@ public class PathInfo
             return id;
         }
 
+        public String getType()
+        {
+            return type;
+        }
+
+        public List<String> getAspectNames()
+        {
+            return aspectNames;
+        }
+
         @Override
         public String toString()
         {
             final StringBuilder sb = new StringBuilder(250);
             sb.append("PathElement [id=").append(id)
                         .append(", name=").append(name)
+                        .append(", type=").append(type)
+                        .append(", aspectNames=").append(aspectNames)
                         .append(']');
             return sb.toString();
         }

--- a/src/main/java/org/alfresco/rest/api/model/PathInfo.java
+++ b/src/main/java/org/alfresco/rest/api/model/PathInfo.java
@@ -81,18 +81,18 @@ public class PathInfo
 
         private String id;
         private String name;
-        private String type;
+        private String nodeType;
         private List<String> aspectNames;
 
         public ElementInfo()
         {
         }
         
-        public ElementInfo(String id, String name, String type, List<String> aspectNames)
+        public ElementInfo(String id, String name, String nodeType, List<String> aspectNames)
         {
             this.id = id;
             this.name = name;
-            this.type = type;
+            this.nodeType = nodeType;
             this.aspectNames = aspectNames;
         }
 
@@ -106,9 +106,9 @@ public class PathInfo
             return id;
         }
 
-        public String getType()
+        public String getNodeType()
         {
-            return type;
+            return nodeType;
         }
 
         public List<String> getAspectNames()
@@ -122,7 +122,7 @@ public class PathInfo
             final StringBuilder sb = new StringBuilder(250);
             sb.append("PathElement [id=").append(id)
                         .append(", name=").append(name)
-                        .append(", type=").append(type)
+                        .append(", nodeType=").append(nodeType)
                         .append(", aspectNames=").append(aspectNames)
                         .append(']');
             return sb.toString();

--- a/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -618,10 +618,11 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         
         assertEquals(site1Id, pathElements.get(2).getName());
         assertEquals("st:site", pathElements.get(2).getType());
-        // Do some 'spot checks' that expected aspects are present.
         assertTrue(pathElements.get(2).getAspectNames().contains("cm:titled"));
-        assertTrue(pathElements.get(2).getAspectNames().contains("sys:undeletable"));
-        assertTrue(pathElements.get(2).getAspectNames().contains("sys:unmovable"));
+        // Check that sys:* is filtered out - to be consistent with other aspect name lists
+        // e.g. /nodes/{nodeId}/children?include=aspectNames
+        assertFalse(pathElements.get(2).getAspectNames().contains("sys:undeletable"));
+        assertFalse(pathElements.get(2).getAspectNames().contains("sys:unmovable"));
 
         assertEquals("documentLibrary", pathElements.get(3).getName());
         assertEquals("cm:folder", pathElements.get(3).getType());

--- a/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -608,13 +608,33 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertTrue(path.getName().startsWith("/Company Home"));
         List<ElementInfo> pathElements = path.getElements();
         assertEquals(7, pathElements.size());
+        
+        // Check path element names and types, and one or two random aspects.
         assertEquals("Company Home", pathElements.get(0).getName());
+        assertEquals("cm:folder", pathElements.get(0).getType());
+        
         assertEquals("Sites", pathElements.get(1).getName());
+        assertEquals("st:sites", pathElements.get(1).getType());
+        
         assertEquals(site1Id, pathElements.get(2).getName());
+        assertEquals("st:site", pathElements.get(2).getType());
+        // Do some 'spot checks' that expected aspects are present.
+        assertTrue(pathElements.get(2).getAspectNames().contains("cm:titled"));
+        assertTrue(pathElements.get(2).getAspectNames().contains("sys:undeletable"));
+        assertTrue(pathElements.get(2).getAspectNames().contains("sys:unmovable"));
+
         assertEquals("documentLibrary", pathElements.get(3).getName());
+        assertEquals("cm:folder", pathElements.get(3).getType());
+        assertTrue(pathElements.get(3).getAspectNames().contains("st:siteContainer"));
+        
         assertEquals(folderA, pathElements.get(4).getName());
+        assertEquals("cm:folder", pathElements.get(4).getType());
+        
         assertEquals(folderB, pathElements.get(5).getName());
+        assertEquals("cm:folder", pathElements.get(5).getType());
+
         assertEquals(folderC, pathElements.get(6).getName());
+        assertEquals("cm:folder", pathElements.get(6).getType());
 
         // Try the above tests with user2 (site consumer)
         setRequestContext(user2);

--- a/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -611,13 +611,13 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         
         // Check path element names and types, and one or two random aspects.
         assertEquals("Company Home", pathElements.get(0).getName());
-        assertEquals("cm:folder", pathElements.get(0).getType());
+        assertEquals("cm:folder", pathElements.get(0).getNodeType());
         
         assertEquals("Sites", pathElements.get(1).getName());
-        assertEquals("st:sites", pathElements.get(1).getType());
+        assertEquals("st:sites", pathElements.get(1).getNodeType());
         
         assertEquals(site1Id, pathElements.get(2).getName());
-        assertEquals("st:site", pathElements.get(2).getType());
+        assertEquals("st:site", pathElements.get(2).getNodeType());
         assertTrue(pathElements.get(2).getAspectNames().contains("cm:titled"));
         // Check that sys:* is filtered out - to be consistent with other aspect name lists
         // e.g. /nodes/{nodeId}/children?include=aspectNames
@@ -625,17 +625,17 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertFalse(pathElements.get(2).getAspectNames().contains("sys:unmovable"));
 
         assertEquals("documentLibrary", pathElements.get(3).getName());
-        assertEquals("cm:folder", pathElements.get(3).getType());
+        assertEquals("cm:folder", pathElements.get(3).getNodeType());
         assertTrue(pathElements.get(3).getAspectNames().contains("st:siteContainer"));
         
         assertEquals(folderA, pathElements.get(4).getName());
-        assertEquals("cm:folder", pathElements.get(4).getType());
+        assertEquals("cm:folder", pathElements.get(4).getNodeType());
         
         assertEquals(folderB, pathElements.get(5).getName());
-        assertEquals("cm:folder", pathElements.get(5).getType());
+        assertEquals("cm:folder", pathElements.get(5).getNodeType());
 
         assertEquals(folderC, pathElements.get(6).getName());
-        assertEquals("cm:folder", pathElements.get(6).getType());
+        assertEquals("cm:folder", pathElements.get(6).getNodeType());
 
         // Try the above tests with user2 (site consumer)
         setRequestContext(user2);

--- a/src/test/java/org/alfresco/rest/api/tests/client/data/PathInfo.java
+++ b/src/test/java/org/alfresco/rest/api/tests/client/data/PathInfo.java
@@ -82,7 +82,7 @@ public class PathInfo
     {
         private String id;
         private String name;
-        private String type;
+        private String nodeType;
         private List<String> aspectNames;
 
         /**
@@ -97,11 +97,11 @@ public class PathInfo
             this(id, name, null, null);
         }
         
-        public ElementInfo(String id, String name, String type, List<String> aspectNames)
+        public ElementInfo(String id, String name, String nodeType, List<String> aspectNames)
         {
             this.id = id;
             this.name = name;
-            this.type = type;
+            this.nodeType = nodeType;
             this.aspectNames = aspectNames;
         }
 
@@ -115,9 +115,9 @@ public class PathInfo
             return id;
         }
 
-        public String getType()
+        public String getNodeType()
         {
-            return type;
+            return nodeType;
         }
 
         public List<String> getAspectNames()
@@ -131,7 +131,7 @@ public class PathInfo
             final StringBuilder sb = new StringBuilder(250);
             sb.append("PathElement [id=").append(id)
                     .append(", name=").append(name)
-                    .append(", type=").append(type)
+                    .append(", nodeType=").append(nodeType)
                     .append(", aspectNames=").append(aspectNames)
                     .append(']');
             return sb.toString();
@@ -144,7 +144,7 @@ public class PathInfo
             ElementInfo other = (ElementInfo) o;
             assertEquals(id, other.getName());
             assertEquals(name, other.getName());
-            assertEquals(type, other.getType());
+            assertEquals(nodeType, other.getNodeType());
         }
     }
 

--- a/src/test/java/org/alfresco/rest/api/tests/client/data/PathInfo.java
+++ b/src/test/java/org/alfresco/rest/api/tests/client/data/PathInfo.java
@@ -67,19 +67,42 @@ public class PathInfo
         return elements;
     }
 
+    @Override
+    public String toString()
+    {
+        final StringBuilder sb = new StringBuilder(120);
+        sb.append("PathInfo [name=").append(name)
+                    .append(", isComplete=").append(isComplete)
+                    .append(", elements=").append(elements)
+                    .append(']');
+        return sb.toString();
+    }
+
     public static class ElementInfo
     {
         private String id;
         private String name;
+        private String type;
+        private List<String> aspectNames;
 
+        /**
+         * Required by jackson deserialisation.
+         */
         public ElementInfo()
         {
         }
 
         public ElementInfo(String id, String name)
         {
+            this(id, name, null, null);
+        }
+        
+        public ElementInfo(String id, String name, String type, List<String> aspectNames)
+        {
             this.id = id;
             this.name = name;
+            this.type = type;
+            this.aspectNames = aspectNames;
         }
 
         public String getName()
@@ -92,6 +115,28 @@ public class PathInfo
             return id;
         }
 
+        public String getType()
+        {
+            return type;
+        }
+
+        public List<String> getAspectNames()
+        {
+            return aspectNames;
+        }
+
+        @Override
+        public String toString()
+        {
+            final StringBuilder sb = new StringBuilder(250);
+            sb.append("PathElement [id=").append(id)
+                    .append(", name=").append(name)
+                    .append(", type=").append(type)
+                    .append(", aspectNames=").append(aspectNames)
+                    .append(']');
+            return sb.toString();
+        }
+        
         public void expected(Object o)
         {
             assertTrue(o instanceof ElementInfo);
@@ -99,6 +144,7 @@ public class PathInfo
             ElementInfo other = (ElementInfo) o;
             assertEquals(id, other.getName());
             assertEquals(name, other.getName());
+            assertEquals(type, other.getType());
         }
     }
 


### PR DESCRIPTION
https://issues.alfresco.com/jira/browse/REPO-2983

This adds extra fields for the path info when ?include=path is present on the nodes URLs.

A separate pull request will be made for the corresponding API explorer changes.