### PR TITLE
REPO-1868: retrieve node actions

### DIFF
--- a/src/main/java/org/alfresco/rest/api/Actions.java
+++ b/src/main/java/org/alfresco/rest/api/Actions.java
@@ -33,5 +33,11 @@ import java.util.List;
 
 public interface Actions
 {
-    List<ActionDefinition> getActionDefinitions(NodeRef nodeRef);
+    List<ActionDefinition> getActionDefinitions(NodeRef nodeRef, SortKey sortKey, Boolean ascending);
+    
+    enum SortKey
+    {
+        NAME,
+        TITLE
+    };
 }

--- a/src/main/java/org/alfresco/rest/api/Actions.java
+++ b/src/main/java/org/alfresco/rest/api/Actions.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api;
+
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.service.cmr.repository.NodeRef;
+
+import java.util.List;
+
+public interface Actions
+{
+    List<ActionDefinition> getActionDefinitions(NodeRef nodeRef);
+}

--- a/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
@@ -33,6 +33,7 @@ import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.NamespacePrefixResolver;
 import org.alfresco.service.namespace.QName;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -53,8 +54,36 @@ public class ActionsImpl implements Actions
     }
 
     @Override
-    public List<ActionDefinition> getActionDefinitions(NodeRef nodeRef)
+    public List<ActionDefinition> getActionDefinitions(NodeRef nodeRef, SortKey sortKey, Boolean ascending)
     {
+        Comparator<? super ActionDefinition> comparator;
+        if (sortKey == null)
+        {
+            sortKey = SortKey.NAME; // default
+        }
+        
+        switch (sortKey)
+        {
+            case TITLE:
+                comparator = Comparator.comparing(ActionDefinition::getTitle);
+                break;
+            case NAME:
+                comparator = Comparator.comparing(ActionDefinition::getName);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid sort key, must be either 'title' or 'name'.");
+        }
+        
+        if (ascending == null)
+        {
+            ascending = true;
+        }
+        if (!ascending)
+        {
+            comparator = comparator.reversed();
+        }
+        
+        
         return actionService.getActionDefinitions(nodeRef).
                 stream().
                 map(actionDefinition -> {
@@ -73,6 +102,7 @@ public class ActionsImpl implements Actions
                             actionDefinition.getTrackStatus(),
                             paramDefs);
                 }).
+                sorted(comparator).
                 collect(Collectors.toList());
     }
 

--- a/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.impl;
+
+import org.alfresco.rest.api.Actions;
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.service.cmr.action.ActionService;
+import org.alfresco.service.cmr.action.ParameterDefinition;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.namespace.NamespacePrefixResolver;
+import org.alfresco.service.namespace.QName;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ActionsImpl implements Actions
+{
+    private ActionService actionService;
+    private NamespacePrefixResolver prefixResolver;
+
+    public void setActionService(ActionService actionService)
+    {
+        this.actionService = actionService;
+    }
+
+    public void setPrefixResolver(NamespacePrefixResolver prefixResolver)
+    {
+        this.prefixResolver = prefixResolver;
+    }
+
+    @Override
+    public List<ActionDefinition> getActionDefinitions(NodeRef nodeRef)
+    {
+        return actionService.getActionDefinitions(nodeRef).
+                stream().
+                map(actionDefinition -> {
+                    List<ActionDefinition.ParameterDefinition> paramDefs =
+                            actionDefinition.
+                                    getParameterDefinitions().
+                                    stream().
+                                    map(this::toModel).
+                                    collect(Collectors.toList());
+                    return new ActionDefinition(
+                            actionDefinition.getName(),
+                            actionDefinition.getTitle(),
+                            actionDefinition.getDescription(),
+                            toShortQNames(actionDefinition.getApplicableTypes()),
+                            actionDefinition.getAdhocPropertiesAllowed(),
+                            actionDefinition.getTrackStatus(),
+                            paramDefs);
+                }).
+                collect(Collectors.toList());
+    }
+
+    private List<String> toShortQNames(Set<QName> types)
+    {
+        return types.
+                stream().
+                map(this::toShortQName).
+                collect(Collectors.toList());
+    }
+
+    private String toShortQName(QName type)
+    {
+        return type.toPrefixString(prefixResolver);
+    }
+
+    private ActionDefinition.ParameterDefinition toModel(ParameterDefinition p)
+    {
+        return new ActionDefinition.ParameterDefinition(
+                p.getName(),
+                toShortQName(p.getType()),
+                p.isMultiValued(),
+                p.isMandatory(),
+                p.getDisplayLabel(),
+                p.getParameterConstraintName()
+        );
+    }
+}

--- a/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
@@ -94,6 +94,7 @@ public class ActionsImpl implements Actions
                                     map(this::toModel).
                                     collect(Collectors.toList());
                     return new ActionDefinition(
+                            actionDefinition.getName(), // ID is a synonym for name.
                             actionDefinition.getName(),
                             actionDefinition.getTitle(),
                             actionDefinition.getDescription(),

--- a/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
+++ b/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
@@ -29,13 +29,20 @@ import java.util.List;
 
 public class ActionDefinition
 {
-    private final String name;
-    private final String title;
-    private final String description;
-    private final List<String> applicableTypes;
-    private final boolean adhocPropertiesAllowed;
-    private final boolean trackStatus;
-    private final List<ParameterDefinition> parameterDefinitions;
+    private String name;
+    private String title;
+    private String description;
+    private List<String> applicableTypes;
+    private boolean adhocPropertiesAllowed;
+    private boolean trackStatus;
+    private List<ParameterDefinition> parameterDefinitions;
+
+    /**
+     * For Jackson deserialisation.
+     */
+    public ActionDefinition()
+    {
+    }
 
     public ActionDefinition(String name,
                             String title,
@@ -54,6 +61,14 @@ public class ActionDefinition
         this.parameterDefinitions = parameterDefinitions;
     }
 
+    /**
+     * Synonym for name.
+     */
+    public String getId()
+    {
+        return getName();
+    }
+    
     public String getName()
     {
         return name;
@@ -91,13 +106,19 @@ public class ActionDefinition
 
     public static class ParameterDefinition
     {
+        private String name;
+        private String type;
+        private boolean multiValued;
+        private boolean mandatory;
+        private String displayLabel;
+        private String parameterConstraintName;
 
-        private final String name;
-        private final String type;
-        private final boolean multiValued;
-        private final boolean mandatory;
-        private final String displayLabel;
-        private final String parameterConstraintName;
+        /**
+         * For Jackson deserialisation.
+         */
+        public ParameterDefinition()
+        {
+        }
 
         public ParameterDefinition(String name,
                                    String type,

--- a/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
+++ b/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.model;
+
+import java.util.List;
+
+public class ActionDefinition
+{
+    private final String name;
+    private final String title;
+    private final String description;
+    private final List<String> applicableTypes;
+    private final boolean adhocPropertiesAllowed;
+    private final boolean trackStatus;
+    private final List<ParameterDefinition> parameterDefinitions;
+
+    public ActionDefinition(String name,
+                            String title,
+                            String description,
+                            List<String> applicableTypes,
+                            boolean adhocPropertiesAllowed,
+                            boolean trackStatus,
+                            List<ParameterDefinition> parameterDefinitions)
+    {
+        this.name = name;
+        this.title = title;
+        this.description = description;
+        this.applicableTypes = applicableTypes;
+        this.adhocPropertiesAllowed = adhocPropertiesAllowed;
+        this.trackStatus = trackStatus;
+        this.parameterDefinitions = parameterDefinitions;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public List<String> getApplicableTypes()
+    {
+        return applicableTypes;
+    }
+
+    public boolean isAdhocPropertiesAllowed()
+    {
+        return adhocPropertiesAllowed;
+    }
+
+    public boolean isTrackStatus()
+    {
+        return trackStatus;
+    }
+
+    public List<ParameterDefinition> getParameterDefinitions()
+    {
+        return parameterDefinitions;
+    }
+
+    public static class ParameterDefinition
+    {
+
+        private final String name;
+        private final String type;
+        private final boolean multiValued;
+        private final boolean mandatory;
+        private final String displayLabel;
+        private final String parameterConstraintName;
+
+        public ParameterDefinition(String name,
+                                   String type,
+                                   boolean multiValued,
+                                   boolean mandatory,
+                                   String displayLabel,
+                                   String parameterConstraintName)
+        {
+            this.name = name;
+            this.type = type;
+            this.multiValued = multiValued;
+            this.mandatory = mandatory;
+            this.displayLabel = displayLabel;
+            this.parameterConstraintName = parameterConstraintName;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public String getType()
+        {
+            return type;
+        }
+
+        public boolean isMultiValued()
+        {
+            return multiValued;
+        }
+
+        public boolean isMandatory()
+        {
+            return mandatory;
+        }
+
+        public String getDisplayLabel()
+        {
+            return displayLabel;
+        }
+
+        public String getParameterConstraintName()
+        {
+            return parameterConstraintName;
+        }
+    }
+}

--- a/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
+++ b/src/main/java/org/alfresco/rest/api/model/ActionDefinition.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 public class ActionDefinition
 {
+    private String id;
     private String name;
     private String title;
     private String description;
@@ -44,7 +45,8 @@ public class ActionDefinition
     {
     }
 
-    public ActionDefinition(String name,
+    public ActionDefinition(String id,
+                            String name,
                             String title,
                             String description,
                             List<String> applicableTypes,
@@ -52,6 +54,7 @@ public class ActionDefinition
                             boolean trackStatus,
                             List<ParameterDefinition> parameterDefinitions)
     {
+        this.id = id;
         this.name = name;
         this.title = title;
         this.description = description;
@@ -62,11 +65,11 @@ public class ActionDefinition
     }
 
     /**
-     * Synonym for name.
+     * Will be used as a synonym for name.
      */
     public String getId()
     {
-        return getName();
+        return id;
     }
     
     public String getName()

--- a/src/main/java/org/alfresco/rest/api/nodes/NodeActionDefinitionsRelation.java
+++ b/src/main/java/org/alfresco/rest/api/nodes/NodeActionDefinitionsRelation.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.nodes;
+
+import org.alfresco.rest.api.Actions;
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.rest.framework.resource.RelationshipResource;
+import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
+import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.util.ParameterCheck;
+
+import java.util.List;
+
+@RelationshipResource(name = "action-definitions",  entityResource = NodesEntityResource.class, title = "Node action definitions")
+public class NodeActionDefinitionsRelation extends AbstractNodeRelation
+        implements RelationshipResourceAction.Read<ActionDefinition>
+{
+    private Actions actions;
+
+    @Override
+    public void afterPropertiesSet()
+    {
+        super.afterPropertiesSet();
+        ParameterCheck.mandatory("actions", actions);
+    }
+
+    public void setActions(Actions actions)
+    {
+        this.actions = actions;
+    }
+
+    @Override
+    public CollectionWithPagingInfo<ActionDefinition> readAll(String entityResourceId, Parameters params)
+    {
+        NodeRef parentNodeRef = nodes.validateOrLookupNode(entityResourceId, null);
+        List<ActionDefinition> actionDefinitions = actions.getActionDefinitions(parentNodeRef);
+
+        // TODO: filter list according to params.getPaging()
+
+        return CollectionWithPagingInfo.asPaged(params.getPaging(), actionDefinitions, false, actionDefinitions.size());
+    }
+}

--- a/src/main/resources/alfresco/public-rest-context.xml
+++ b/src/main/resources/alfresco/public-rest-context.xml
@@ -542,6 +542,21 @@
         <property name="permissionService" ref="permissionService"/>
     </bean>
 
+    <bean id="actions" class="org.alfresco.rest.api.impl.ActionsImpl">
+        <property name="actionService" ref="ActionService"/>
+        <property name="prefixResolver" ref="namespaceService"/>
+    </bean>
+    <bean id="Actions" class="org.springframework.aop.framework.ProxyFactoryBean">
+        <property name="proxyInterfaces" value="org.alfresco.rest.api.Actions"/>
+        <property name="target" ref="actions" />
+        <property name="interceptorNames">
+            <list>
+                <idref bean="legacyExceptionInterceptor" />
+            </list>
+        </property>
+    </bean>
+
+
     <bean id="Downloads" class="org.springframework.aop.framework.ProxyFactoryBean">
             <property name="proxyInterfaces">
             <value>org.alfresco.rest.api.Downloads</value>
@@ -919,6 +934,10 @@
 
     <bean class="org.alfresco.rest.api.nodes.NodeTagsRelation">
         <property name="tags" ref="Tags" />
+    </bean>
+
+    <bean class="org.alfresco.rest.api.nodes.NodeActionDefinitionsRelation" parent="baseNodeRelation">
+        <property name="actions" ref="Actions"/>
     </bean>
 
     <bean class="org.alfresco.rest.api.trashcan.TrashcanEntityResource">

--- a/src/test/java/org/alfresco/rest/api/tests/TestActions.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestActions.java
@@ -399,6 +399,12 @@ public class TestActions extends AbstractBaseApiTest
             assertEquals(expectedActions, retrievedActions);
         }
         
+        // Badly formed request -> 400
+        {
+            PublicApiClient.Paging paging = getPaging(0, -1); // -1 is not acceptable
+            actions.getActionDefinitionsForNode(validNode.getId(), createParams(paging, null), 400);
+        }
+        
         // Non-existent node ID
         {
             NodeRef nodeRef = new NodeRef(
@@ -407,6 +413,12 @@ public class TestActions extends AbstractBaseApiTest
             assertFalse("Test pre-requisite: node must not exist", nodeService.exists(nodeRef));
             
             actions.getActionDefinitionsForNode(nodeRef.getId(), emptyParams, 404);
+        }
+        
+        // Unauthorized -> 401
+        {
+            publicApiClient.setRequestContext(new RequestContext(account1.getId(), person1, "invalid-password"));
+            actions.getActionDefinitionsForNode(validNode.getId(), emptyParams, 401);
         }
     }
 }

--- a/src/test/java/org/alfresco/rest/api/tests/TestActions.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestActions.java
@@ -28,38 +28,52 @@ package org.alfresco.rest.api.tests;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.rest.api.tests.client.Pair;
 import org.alfresco.rest.api.tests.client.PublicApiClient;
 import org.alfresco.rest.api.tests.client.PublicApiClient.ListResponse;
 import org.alfresco.rest.api.tests.client.RequestContext;
+import org.alfresco.service.cmr.action.ActionService;
+import org.alfresco.service.cmr.action.ParameterizedItemDefinition;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.QName;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EmptyStackException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestActions extends AbstractBaseApiTest
 {
     private NodeService nodeService;
+    private ActionService actionService;
     private PublicApiClient.Actions actions;
     private RepoService.TestNetwork account1;
     private Iterator<RepoService.TestNetwork> accountsIt;
     private Iterator<String> account1PersonIt;
     private final static Map<String, String> emptyParams = Collections.EMPTY_MAP;
+    private final static Log logger = LogFactory.getLog(TestActions.class);
 
     @Before
     public void setUp() throws Exception
     {
         nodeService = applicationContext.getBean("NodeService", NodeService.class);
+        actionService = applicationContext.getBean("ActionService", ActionService.class);
         actions = publicApiClient.actions();
 
         accountsIt = getTestFixture().getNetworksIt();
@@ -105,21 +119,207 @@ public class TestActions extends AbstractBaseApiTest
         }
 
         AuthenticationUtil.setFullyAuthenticatedUser(person1);
+
+        String myNode = getMyNodeId();
+        NodeRef validNode = nodeService.createNode(
+                new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, myNode),
+                ContentModel.ASSOC_CONTAINS,
+                QName.createQName("test", "test-node"),
+                ContentModel.TYPE_CONTENT).getChildRef();
         
         // Get the actions available using a specific node ID
         {
-            String myNode = getMyNodeId();
-            NodeRef validNode = nodeService.createNode(
-                    new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, myNode),
-                    ContentModel.ASSOC_CONTAINS,
-                    QName.createQName("test", "test-node"),
-                    ContentModel.TYPE_CONTENT).getChildRef();
             
             ListResponse<ActionDefinition> actionDefs = actions.getActionDefinitionsForNode(validNode.getId(), emptyParams, 200);
             
             assertNotNull("Action definition list should not be null", actionDefs);
             assertFalse("Action definition list should not be empty", actionDefs.getList().isEmpty());
         }
+
+        // Test paging
+        {
+            // Default sort order is by name ascending
+            List<String> expectedNames =
+                    actionService.getActionDefinitions(validNode).
+                    stream().
+                    sorted(Comparator.comparing(org.alfresco.service.cmr.action.ActionDefinition::getName)).
+                    map(ParameterizedItemDefinition::getName).        
+                    collect(Collectors.toList());
+            
+            // Retrieve all action defs using the REST API - then check that they match
+            // the list retrieved directly from the ActionService.
+            PublicApiClient.Paging paging = getPaging(0, Integer.MAX_VALUE);
+            
+            // Retrieve all the results, sorted, on one page
+            ListResponse<ActionDefinition> actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, null), 200);
+            
+            // ActionService and the REST API return very different types, so mapping both lists
+            // to Strings to make a simple comparison easy.
+            List<String> actionNames = actionDefs.getList().stream().
+                    map(ActionDefinition::getName).
+                    collect(Collectors.toList());
+            
+            // Check the whole lists match
+            assertEquals(expectedNames, actionNames);
+
+            final int pageSize = 2;
+            if (expectedNames.size() < ((pageSize * 2) + 1)) // need at least 3 pages worth
+            {
+                // By default there are plenty of actions available to the created node. If this
+                // ceases to be the case in the future, this test should be modified to make sure
+                // there are sufficient action definitions to be listed for the node.
+                fail("Cannot perform useful paging tests - too few action definitions.");
+            }
+            else
+            {
+                // Page 1
+                paging = getPaging(0, pageSize);
+                actionDefs = actions.
+                        getActionDefinitionsForNode(validNode.getId(), createParams(paging, null), 200);
+                assertEquals(pageSize, actionDefs.getList().size());
+                assertEquals(pageSize, (long) actionDefs.getPaging().getCount());
+                assertEquals(expectedNames.size(), (int) actionDefs.getPaging().getTotalItems());
+                assertTrue(actionDefs.getPaging().getHasMoreItems());
+
+                // Page 2
+                paging = getPaging(pageSize, pageSize, expectedNames.size(), expectedNames.size());
+                actionDefs = actions.
+                        getActionDefinitionsForNode(validNode.getId(), createParams(paging, null), 200);
+                assertEquals(pageSize, actionDefs.getList().size());
+                assertEquals(pageSize, (long) actionDefs.getPaging().getCount());
+                assertEquals(expectedNames.size(), (int) actionDefs.getPaging().getTotalItems());
+                assertTrue(actionDefs.getPaging().getHasMoreItems());
+                
+                // Get a 'page' consisting of just the last item, regardless of pageSize 
+                paging = getPaging(expectedNames.size()-1, pageSize);
+                actionDefs = actions.
+                        getActionDefinitionsForNode(validNode.getId(), createParams(paging, null), 200);
+                assertEquals(1, actionDefs.getList().size());
+                assertEquals(1L, (long) actionDefs.getPaging().getCount());
+                assertEquals(expectedNames.size(), (int) actionDefs.getPaging().getTotalItems());
+                assertFalse(actionDefs.getPaging().getHasMoreItems());
+            }
+        }
+        
+        // Test sorting by title
+        {
+            // Retrieve all the actions directly using the ActionService and sort by title.
+            List<Pair<String, String>> expectedActions =
+                    actionService.getActionDefinitions(validNode).
+                            stream().
+                            sorted(Comparator.comparing(org.alfresco.service.cmr.action.ActionDefinition::getTitle)).
+                            map(act -> new Pair<>(act.getName(), act.getTitle())).
+                            collect(Collectors.toList());
+
+            // Retrieve all action defs using the REST API - then check that they match
+            // the list retrieved directly from the ActionService.
+            PublicApiClient.Paging paging = getPaging(0, Integer.MAX_VALUE);
+
+            // Retrieve all the results, sorted, on one page
+            Map<String, String> orderBy = Collections.singletonMap("orderBy", "title");
+            ListResponse<ActionDefinition> actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+            
+            List<Pair<String, String>> retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            assertEquals(expectedActions, retrievedActions);
+
+            // Again, by title, but with explicit ascending sort order
+            orderBy = Collections.singletonMap("orderBy", "title asc");
+            actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            assertEquals(expectedActions, retrievedActions);
+
+
+            // Descending sort order
+            orderBy = Collections.singletonMap("orderBy", "title desc");
+            actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            Collections.reverse(expectedActions);
+            assertEquals(expectedActions, retrievedActions);
+            
+            // Combine paging with sorting by title, descending.
+            final int pageSize = 2;
+            paging = getPaging(pageSize, pageSize);
+            actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+            
+            assertEquals(expectedActions.subList(pageSize, pageSize*2), retrievedActions);
+        }
+
+        // Test explicit sorting by name
+        {
+            // Retrieve all the actions directly using the ActionService and sort by name.
+            List<Pair<String, String>> expectedActions =
+                    actionService.getActionDefinitions(validNode).
+                            stream().
+                            sorted(Comparator.comparing(org.alfresco.service.cmr.action.ActionDefinition::getName)).
+                            map(act -> new Pair<>(act.getName(), act.getTitle())).
+                            collect(Collectors.toList());
+
+            // Retrieve all action defs using the REST API - then check that they match
+            // the list retrieved directly from the ActionService.
+            PublicApiClient.Paging paging = getPaging(0, Integer.MAX_VALUE);
+
+            // Retrieve all the results, sorted, on one page
+            Map<String, String> orderBy = Collections.singletonMap("orderBy", "name");
+            ListResponse<ActionDefinition> actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            List<Pair<String, String>> retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            assertEquals(expectedActions, retrievedActions);
+
+            // Again, by name, but with explicit ascending sort order
+            orderBy = Collections.singletonMap("orderBy", "name asc");
+            actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            assertEquals(expectedActions, retrievedActions);
+
+
+            // Descending sort order
+            orderBy = Collections.singletonMap("orderBy", "name desc");
+            actionDefs = actions.
+                    getActionDefinitionsForNode(validNode.getId(), createParams(paging, orderBy), 200);
+
+            retrievedActions = actionDefs.getList().stream().
+                    map(act -> new Pair<>(act.getName(), act.getTitle())).
+                    collect(Collectors.toList());
+
+            // Check the whole lists match
+            Collections.reverse(expectedActions);
+            assertEquals(expectedActions, retrievedActions);
+        }
+        
         
         // Non-existent node ID
         {

--- a/src/test/java/org/alfresco/rest/api/tests/TestActions.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestActions.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2017 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.tests;
+
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.rest.api.tests.client.PublicApiClient;
+import org.alfresco.rest.api.tests.client.PublicApiClient.ListResponse;
+import org.alfresco.rest.api.tests.client.PublicApiException;
+import org.alfresco.rest.api.tests.client.RequestContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.EmptyStackException;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class TestActions extends AbstractBaseApiTest
+{
+    private PublicApiClient.Actions actions;
+    private RepoService.TestNetwork account1;
+    private Iterator<RepoService.TestNetwork> accountsIt;
+    private Iterator<String> account1PersonIt;
+    
+    @Before
+    public void setUp() throws Exception
+    {
+        actions = publicApiClient.actions();
+
+        accountsIt = getTestFixture().getNetworksIt();
+        account1 = accountsIt.next();
+        account1PersonIt = account1.getPersonIds().iterator();
+        
+        // Capture authentication pre-test, so we can restore it again afterwards.
+        AuthenticationUtil.pushAuthentication();
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Restore authentication to pre-test state.
+        try
+        {
+            AuthenticationUtil.popAuthentication();
+        }
+        catch(EmptyStackException e)
+        {
+            // Nothing to do.
+        }
+    }
+    
+    @Override
+    public String getScope()
+    {
+        return "public";
+    }
+    
+    @Test
+    public void canGetActionDefinitionsForNode() throws PublicApiException
+    {
+        final String person1 = account1PersonIt.next();
+        publicApiClient.setRequestContext(new RequestContext(account1.getId(), person1));
+        
+        ListResponse<ActionDefinition> actionDefs = actions.getActionDefinitionsForNode("-my-", null);
+        assertNotNull("Action definition list should not be null", actionDefs);
+        assertFalse("Action definition list should not be empty", actionDefs.getList().isEmpty());
+    }
+}

--- a/src/test/java/org/alfresco/rest/api/tests/client/Pair.java
+++ b/src/test/java/org/alfresco/rest/api/tests/client/Pair.java
@@ -76,4 +76,10 @@ public class Pair<T1, T2>
 	public T2 getSecond() {
 		return second;
 	}
+
+	@Override
+	public String toString()
+	{
+		return String.format("Pair<%s,%s>", first, second);
+	}
 }

--- a/src/test/java/org/alfresco/rest/api/tests/client/PublicApiClient.java
+++ b/src/test/java/org/alfresco/rest/api/tests/client/PublicApiClient.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.alfresco.cmis.client.impl.AlfrescoObjectFactoryImpl;
 import org.alfresco.opencmis.CMISDispatcherRegistry.Binding;
 import org.alfresco.rest.api.model.ActionDefinition;
@@ -130,6 +131,7 @@ public class PublicApiClient
     
 
     private ThreadLocal<RequestContext> rc = new ThreadLocal<RequestContext>();
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     public PublicApiClient(PublicApiHttpClient client, UserDataService userDataService)
     {
@@ -2685,17 +2687,17 @@ public class PublicApiClient
 
         private ActionDefinition parseActionDefinition(JSONObject entry)
         {
-            ActionDefinition def = new ActionDefinition(
-                    (String) entry.get("name"),
-                    (String) entry.get("title"),
-                    (String) entry.get("description"),
-                    null,
-                    (Boolean) entry.get("adhocPropertiesAllowed"),
-                    (Boolean) entry.get("trackStatus"),
-                    null
-            );
+            ActionDefinition def = null;
+            try
+            {
+                def = objectMapper.readValue(entry.toString(), ActionDefinition.class);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException("Unable to parse ActionDefinition JSON", e);
+            }
+            
             return def;
         }
-
     }
 }

--- a/src/test/java/org/alfresco/rest/api/tests/client/PublicApiClient.java
+++ b/src/test/java/org/alfresco/rest/api/tests/client/PublicApiClient.java
@@ -2642,10 +2642,14 @@ public class PublicApiClient
     
     public class Actions extends AbstractProxy
     {
-        public ListResponse<ActionDefinition> getActionDefinitionsForNode(String nodeId, Map<String, String> params)
+        public ListResponse<ActionDefinition> getActionDefinitionsForNode(String nodeId,
+                                                                          Map<String, String> params,
+                                                                          int expectedStatus)
                 throws PublicApiException
         {
-            HttpResponse response = getAll("nodes", nodeId, "action-definitions", null, params, "Failed to get actions");
+            HttpResponse response = getAll("nodes", nodeId, "action-definitions",
+                    null, params, "Unexpected response", expectedStatus);
+            
             if (response != null && response.getJsonResponse() != null)
             {
                 JSONObject jsonList = (JSONObject) response.getJsonResponse().get("list");


### PR DESCRIPTION
Added API and tests for retrieving the action definitions available for a particular node.

This review is for the implementation of the `GET /nodes/{nodeId}/action-definitions` endpoint, as defined in REPO-1206

The results are paged and sorted (default is by ascending name)

Issue: https://issues.alfresco.com/jira/browse/REPO-1868
Build: https://bamboo.alfresco.com/bamboo/browse/PLAT-RAPI32
