### PR TITLE
REPO-1309: Execute an action asynchronously

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
@@ -216,18 +216,17 @@ public class ActionsImpl implements Actions
             throw new EntityNotFoundException(action.getActionDefinitionId());
         }
 
-        // Check target id.
-
-        if (action.getTargetId() == null || action.getTargetId().isEmpty())
+        // targetId is optional, however, currently targetId must be a valid node ID.
+        NodeRef actionedUponNodeRef = null;
+        if (action.getTargetId() != null && !action.getTargetId().isEmpty())
         {
-            throw new InvalidArgumentException("targetId missing");
-        }
+            // Does it exist in the repo?
+            actionedUponNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, action.getTargetId());
 
-        // Does it exist in the repo?
-        NodeRef actionedUponNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, action.getTargetId());
-        if (!nodeService.exists(actionedUponNodeRef))
-        {
-            throw new EntityNotFoundException(action.getTargetId());
+            if (!nodeService.exists(actionedUponNodeRef))
+            {
+                throw new EntityNotFoundException(action.getTargetId());
+            }
         }
 
         org.alfresco.service.cmr.action.Action cmrAction;

--- a/src/test/java/org/alfresco/rest/api/tests/TestActions.java
+++ b/src/test/java/org/alfresco/rest/api/tests/TestActions.java
@@ -536,14 +536,6 @@ public class TestActions extends AbstractBaseApiTest
             actions.executeAction(action, emptyParams, 404);
         }
 
-        // targetId missing but required by the action.
-        {
-            Action action = new Action();
-            action.setActionDefinitionId(AddFeaturesActionExecuter.NAME);
-
-            actions.executeAction(action, emptyParams, 400);
-        }
-
         // Non-existent targetId
         {
             NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "750a2867-ecfa-478c-8343-fa0e39d27be3");


### PR DESCRIPTION
   - targetId is now optional, however, currently targetId must be a valid node ID.