### PR TITLE
REPO-2093: Allow site managers to accept and reject site invitations

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/SiteMembershipRequestsExceptionHandler.java
+++ b/src/main/java/org/alfresco/rest/api/impl/SiteMembershipRequestsExceptionHandler.java
@@ -25,19 +25,20 @@
  */
 package org.alfresco.rest.api.impl;
 
+import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.rest.framework.core.exceptions.NotFoundException;
 import org.alfresco.service.cmr.invitation.InvitationExceptionForbidden;
 
 public class SiteMembershipRequestsExceptionHandler extends DefaultExceptionHandler
 {
-	@Override
-	public boolean handle(Throwable t)
-	{
-		if(t instanceof InvitationExceptionForbidden)
-		{
-			// Note: security, no message to indicate why
-			throw new NotFoundException();
-		}
-		return super.handle(t);
-	}
+    @Override
+    public boolean handle(Throwable t)
+    {
+        if (t instanceof AccessDeniedException || t instanceof InvitationExceptionForbidden)
+        {
+            // Note: security, no message to indicate why
+            throw new NotFoundException();
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/alfresco/rest/api/impl/SiteMembershipRequestsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/SiteMembershipRequestsImpl.java
@@ -53,6 +53,7 @@ import org.alfresco.rest.api.model.SiteMembershipRejection;
 import org.alfresco.rest.api.model.SiteMembershipRequest;
 import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
 import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
+import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
 import org.alfresco.rest.framework.core.exceptions.RelationshipResourceNotFoundException;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Paging;
@@ -62,6 +63,7 @@ import org.alfresco.rest.framework.resource.parameters.where.QueryHelper;
 import org.alfresco.rest.workflow.api.impl.MapBasedQueryWalker;
 import org.alfresco.service.cmr.invitation.Invitation;
 import org.alfresco.service.cmr.invitation.Invitation.ResourceType;
+import org.alfresco.service.cmr.invitation.InvitationExceptionForbidden;
 import org.alfresco.service.cmr.invitation.InvitationExceptionNotFound;
 import org.alfresco.service.cmr.invitation.InvitationSearchCriteria.InvitationType;
 import org.alfresco.service.cmr.invitation.InvitationService;
@@ -586,7 +588,14 @@ public class SiteMembershipRequestsImpl implements SiteMembershipRequests
             throw new RelationshipResourceNotFoundException(siteId, inviteeId);
         }
 
-        invitationService.approve(invitation.getInviteId(), "");
+        try
+        {
+            invitationService.approve(invitation.getInviteId(), "");
+        }
+        catch (InvitationExceptionForbidden ex)
+        {
+            throw new PermissionDeniedException();
+        }
 
         if (siteMembershipApproval != null && !(siteMembershipApproval.getRole() == null || siteMembershipApproval.getRole().isEmpty()))
         {
@@ -646,7 +655,14 @@ public class SiteMembershipRequestsImpl implements SiteMembershipRequests
             reason = siteMembershipRejection.getComment();
         }
 
-        invitationService.reject(invitation.getInviteId(), reason);
+        try
+        {
+            invitationService.reject(invitation.getInviteId(), reason);
+        }
+        catch (InvitationExceptionForbidden ex)
+        {
+            throw new PermissionDeniedException();
+        }
     }
 
     /**

--- a/src/main/java/org/alfresco/rest/api/sites/SiteMembershipRequestsRelation.java
+++ b/src/main/java/org/alfresco/rest/api/sites/SiteMembershipRequestsRelation.java
@@ -32,6 +32,8 @@ import org.alfresco.rest.api.model.SiteMembershipApproval;
 import org.alfresco.rest.api.model.SiteMembershipRejection;
 import org.alfresco.rest.framework.Operation;
 import org.alfresco.rest.framework.WebApiDescription;
+import org.alfresco.rest.framework.WebApiParam;
+import org.alfresco.rest.framework.core.ResourceParameter;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 import org.alfresco.rest.framework.webscripts.WithResponse;
@@ -56,6 +58,7 @@ public class SiteMembershipRequestsRelation implements InitializingBean
     }
 
     @Operation("approve")
+    @WebApiParam(name = "siteMembershipApproval", title = "Site membership approval", description = "Site membership approval", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Approve a site membership request.", description = "Approve a site membership request.", successStatus = HttpServletResponse.SC_OK)
     public void approve(String siteId, String invitationId, SiteMembershipApproval siteMembershipApproval, Parameters parameters, WithResponse withResponse)
     {
@@ -63,6 +66,7 @@ public class SiteMembershipRequestsRelation implements InitializingBean
     }
 
     @Operation("reject")
+    @WebApiParam(name = "siteMembershipRejection", title = "Site membership rejection", description = "Site membership rejection", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Reject a site membership request.", description = "Reject a site membership request.", successStatus = HttpServletResponse.SC_OK)
     public void reject(String siteId, String invitationId, SiteMembershipRejection siteMembershipRejection, Parameters parameters, WithResponse withResponse)
     {


### PR DESCRIPTION
   - updated site membership requests exception handler to allow 403 exception in some use cases
   - fixed issue when receiving null body for approve and reject