### PR TITLE
MNT-20200 Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS) CWE ID 80

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,13 @@
             <version>${dependency.opencmis.version}</version>
         </dependency>
 
+	<!-- MNT-20200 OWASP Library for Security Fix -->
+	<dependency>
+	   <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+	   <artifactId>owasp-java-html-sanitizer</artifactId>
+	   <version>20181114.1</version>
+	</dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/alfresco/web/app/servlet/KerberosAuthenticationFilter.java
+++ b/src/main/java/org/alfresco/web/app/servlet/KerberosAuthenticationFilter.java
@@ -25,20 +25,21 @@
  */
 package org.alfresco.web.app.servlet;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import org.alfresco.repo.web.auth.WebCredentials;
+import org.alfresco.repo.webdav.auth.AuthenticationDriver;
+import org.alfresco.repo.webdav.auth.BaseKerberosAuthenticationFilter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
-import org.alfresco.repo.web.auth.WebCredentials;
-import org.alfresco.repo.webdav.auth.AuthenticationDriver;
-import org.alfresco.repo.webdav.auth.BaseKerberosAuthenticationFilter;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 /**
  * Kerberos Authentication Filter Class
@@ -62,7 +63,7 @@ public class KerberosAuthenticationFilter extends BaseKerberosAuthenticationFilt
         super.init();
 
         // Use the web client user attribute name
-        setUserAttributeName(AuthenticationDriver.AUTHENTICATION_USER);
+            setUserAttributeName(AuthenticationDriver.AUTHENTICATION_USER);
     }
     
     /* (non-Javadoc)
@@ -92,21 +93,23 @@ public class KerberosAuthenticationFilter extends BaseKerberosAuthenticationFilt
     /* (non-Javadoc)
      * @see org.alfresco.repo.webdav.auth.BaseSSOAuthenticationFilter#writeLoginPageLink(javax.servlet.ServletContext, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
      */
-    @Override
-    protected void writeLoginPageLink(ServletContext context, HttpServletRequest req, HttpServletResponse resp)
-            throws IOException
+    @Override protected void writeLoginPageLink(ServletContext context, HttpServletRequest req, HttpServletResponse resp) throws IOException
     {
-        String redirectURL = req.getRequestURI();
-        resp.setContentType("text/html; charset=UTF-8");
-        resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            String redirectURL = req.getRequestURI();
+            resp.setContentType("text/html; charset=UTF-8");
+            resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        final PrintWriter out = resp.getWriter();
-        out.println("<html><head>");
-        // Remove the auto refresh to avoid refresh loop, MNT-16931
-//         out.println("<meta http-equiv=\"Refresh\" content=\"0; url=" + redirectURL + "\">");
-        out.println("</head><body><p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>");
-        out.println("</body></html>");
-        out.close();
+            final PrintWriter out = resp.getWriter();
+            out.println("<html><head>");
+            // Remove the auto refresh to avoid refresh loop, MNT-16931
+            //         out.println("<meta http-equiv=\"Refresh\" content=\"0; url=" + redirectURL + "\">");
+            // out.println("</head><body><p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>");
+            // MNT-20200 (LM-190130): Sanitise url on anchor
+            out.println("</head><body>");
+            PolicyFactory policy = Sanitizers.FORMATTING.and(Sanitizers.LINKS).and(Sanitizers.BLOCKS);
+            out.println(policy.sanitize("<p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>"));
+            out.println("</body></html>");
+            out.close();
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/alfresco/web/app/servlet/NTLMAuthenticationFilter.java
+++ b/src/main/java/org/alfresco/web/app/servlet/NTLMAuthenticationFilter.java
@@ -25,20 +25,21 @@
  */
 package org.alfresco.web.app.servlet;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import org.alfresco.repo.web.auth.WebCredentials;
+import org.alfresco.repo.webdav.auth.AuthenticationDriver;
+import org.alfresco.repo.webdav.auth.BaseNTLMAuthenticationFilter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
-import org.alfresco.repo.web.auth.WebCredentials;
-import org.alfresco.repo.webdav.auth.AuthenticationDriver;
-import org.alfresco.repo.webdav.auth.BaseNTLMAuthenticationFilter;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 /**
  * Web-client NTLM Authentication Filter Class
@@ -61,7 +62,7 @@ public class NTLMAuthenticationFilter extends BaseNTLMAuthenticationFilter
         super.init();
         
         // Use the web client user attribute name
-        setUserAttributeName(AuthenticationDriver.AUTHENTICATION_USER);
+        setUserAttributeName(AuthenticationDriver.AUTHENTICATION_USER);      
     }
     
     /* (non-Javadoc)
@@ -91,9 +92,7 @@ public class NTLMAuthenticationFilter extends BaseNTLMAuthenticationFilter
     /* (non-Javadoc)
      * @see org.alfresco.repo.webdav.auth.BaseSSOAuthenticationFilter#writeLoginPageLink(javax.servlet.ServletContext, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
      */
-    @Override
-    protected void writeLoginPageLink(ServletContext context, HttpServletRequest req, HttpServletResponse resp)
-            throws IOException
+    @Override protected void writeLoginPageLink(ServletContext context, HttpServletRequest req, HttpServletResponse resp) throws IOException
     {
         String redirectURL = req.getRequestURI();
         resp.setContentType("text/html; charset=UTF-8");
@@ -102,12 +101,16 @@ public class NTLMAuthenticationFilter extends BaseNTLMAuthenticationFilter
         final PrintWriter out = resp.getWriter();
         out.println("<html><head>");
         // Remove the auto refresh to avoid refresh loop, MNT-16931
-//         out.println("<meta http-equiv=\"Refresh\" content=\"0; url=" + redirectURL + "\">");
-        out.println("</head><body><p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>");
+        //         out.println("<meta http-equiv=\"Refresh\" content=\"0; url=" + redirectURL + "\">");
+        // out.println("</head><body><p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>");
+        // MNT-20200 (LM-190130): Sanitise url on anchor
+        out.println("</head><body>");
+        PolicyFactory policy = Sanitizers.FORMATTING.and(Sanitizers.LINKS).and(Sanitizers.BLOCKS);
+        out.println(policy.sanitize("<p>Please <a href=\"" + redirectURL + "\">log in</a>.</p>"));
         out.println("</body></html>");
         out.close();
     }
-
+    
     /* (non-Javadoc)
      * @see org.alfresco.repo.webdav.auth.BaseNTLMAuthenticationFilter#getLogger()
      */


### PR DESCRIPTION
This call contains a cross-site scripting (XSS) flaw. The application populates the HTTP response with untrusted input, allowing an attacker to embed malicious content, such as Javascript code, which will be executed in the context of the victim's browser. Use contextual escaping on all untrusted data before using it to construct any portion of an HTTP response.

Instances found via static scan

* alfresco.war/alfresco-enterprise-remote-api-6.25.jar | .../KerberosAuthenticationFilter.java 90
* alfresco.war/alfresco-enterprise-remote-api-6.25.jar | .../NTLMAuthenticationFilter.java 89

Fix

* imported OWASP Java html sanitizer library as new maven dependency
* sanitized redirectURL in KerberosAuthenticationFilter and NTLMAuthenticationFilter classes