### PR TITLE
MNT-20199 Improper Output Neutralization for Logs CWE ID 117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,13 @@
             <version>${dependency.opencmis.version}</version>
         </dependency>
 
+	<!-- MNT20199 security patch for logging neutralisation -->
+        <dependency>
+            <groupId>org.owasp.esapi</groupId>
+            <artifactId>esapi</artifactId>
+            <version>2.1.0.1</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/alfresco/apache/log4j/NewLinePatternLayout.java
+++ b/src/main/java/org/alfresco/apache/log4j/NewLinePatternLayout.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * Alfresco Repository WAR Community
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.apache.log4j;
+
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+import org.owasp.esapi.ESAPI;
+/**
+ * Custom Log Pattern Layout to neutralize logs
+ * 
+ * MNT-20199 Improper Output Neutralization for Logs CWE ID 117
+ * Creator: aioobe (https://stackoverflow.com/questions/30912182/how-to-resolve-cwe-117-issue )
+ * LM_2019-01-30
+ * */
+
+public class NewLinePatternLayout extends PatternLayout {
+
+	public NewLinePatternLayout() { }
+
+    public NewLinePatternLayout(String pattern) {
+        super(pattern);
+    }
+    
+    public String format(LoggingEvent event) {
+        String original = super.format(event);
+
+        // ensure no CRLF injection into logs for forging records
+        String clean = original.replace('\n', '_').replace('\r', '_');
+        if (ESAPI.securityConfiguration().getLogEncodingRequired()) {
+        	//Encode data for use in HTML using HTML entity encoding
+            clean = ESAPI.encoder().encodeForHTML(clean);
+        }
+        //insert new line for better readability of the logs
+        StringBuilder sb = new StringBuilder(clean + "\n");
+
+        return sb.toString();
+    }
+}

--- a/src/main/resources/ESAPI.properties
+++ b/src/main/resources/ESAPI.properties
@@ -1,0 +1,452 @@
+#
+# OWASP Enterprise Security API (ESAPI) Properties file -- PRODUCTION Version
+# 
+# This file is part of the Open Web Application Security Project (OWASP)
+# Enterprise Security API (ESAPI) project. For details, please see
+# http://www.owasp.org/index.php/ESAPI.
+#
+# Copyright (c) 2008,2009 - The OWASP Foundation
+#
+# DISCUSS: This may cause a major backwards compatibility issue, etc. but
+#		   from a name space perspective, we probably should have prefaced
+#		   all the property names with ESAPI or at least OWASP. Otherwise
+#		   there could be problems is someone loads this properties file into
+#		   the System properties.  We could also put this file into the
+#		   esapi.jar file (perhaps as a ResourceBundle) and then allow an external
+#		   ESAPI properties be defined that would overwrite these defaults.
+#		   That keeps the application's properties relatively simple as usually
+#		   they will only want to override a few properties. If looks like we
+#		   already support multiple override levels of this in the
+#		   DefaultSecurityConfiguration class, but I'm suggesting placing the
+#		   defaults in the esapi.jar itself. That way, if the jar is signed,
+#		   we could detect if those properties had been tampered with. (The
+#		   code to check the jar signatures is pretty simple... maybe 70-90 LOC,
+#		   but off course there is an execution penalty (similar to the way
+#		   that the separate sunjce.jar used to be when a class from it was
+#		   first loaded). Thoughts?
+###############################################################################
+#
+# WARNING: Operating system protection should be used to lock down the .esapi
+# resources directory and all the files inside and all the directories all the
+# way up to the root directory of the file system.  Note that if you are using
+# file-based implementations, that some files may need to be read-write as they
+# get updated dynamically.
+#
+# Before using, be sure to update the MasterKey and MasterSalt as described below.
+# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
+#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
+#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
+#		able to decrypt your data with ESAPI 2.0.
+#
+#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
+#
+#===========================================================================
+# ESAPI Configuration
+#
+# If true, then print all the ESAPI properties set here when they are loaded.
+# If false, they are not printed. Useful to reduce output when running JUnit tests.
+# If you need to troubleshoot a properties related problem, turning this on may help.
+# This is 'false' in the src/test/resources/.esapi version. It is 'true' by
+# default for reasons of backward compatibility with earlier ESAPI versions.
+ESAPI.printProperties=true
+
+# ESAPI is designed to be easily extensible. You can use the reference implementation
+# or implement your own providers to take advantage of your enterprise's security
+# infrastructure. The functions in ESAPI are referenced using the ESAPI locator, like:
+#
+#    String ciphertext =
+#		ESAPI.encryptor().encrypt("Secret message");   // Deprecated in 2.0
+#    CipherText cipherText =
+#		ESAPI.encryptor().encrypt(new PlainText("Secret message")); // Preferred
+#
+# Below you can specify the classname for the provider that you wish to use in your
+# application. The only requirement is that it implement the appropriate ESAPI interface.
+# This allows you to switch security implementations in the future without rewriting the
+# entire application.
+#
+# ExperimentalAccessController requires ESAPI-AccessControlPolicy.xml in .esapi directory
+ESAPI.AccessControl=org.owasp.esapi.reference.DefaultAccessController
+# FileBasedAuthenticator requires users.txt file in .esapi directory
+ESAPI.Authenticator=org.owasp.esapi.reference.FileBasedAuthenticator
+ESAPI.Encoder=org.owasp.esapi.reference.DefaultEncoder
+ESAPI.Encryptor=org.owasp.esapi.reference.crypto.JavaEncryptor
+
+ESAPI.Executor=org.owasp.esapi.reference.DefaultExecutor
+ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
+ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
+# Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
+ESAPI.Logger=org.owasp.esapi.reference.Log4JLogFactory
+#ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
+ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
+ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator
+
+#===========================================================================
+# ESAPI Authenticator
+#
+Authenticator.AllowedLoginAttempts=3
+Authenticator.MaxOldPasswordHashes=13
+Authenticator.UsernameParameterName=username
+Authenticator.PasswordParameterName=password
+# RememberTokenDuration (in days)
+Authenticator.RememberTokenDuration=14
+# Session Timeouts (in minutes)
+Authenticator.IdleTimeoutDuration=20
+Authenticator.AbsoluteTimeoutDuration=120
+
+#===========================================================================
+# ESAPI Encoder
+#
+# ESAPI canonicalizes input before validation to prevent bypassing filters with encoded attacks.
+# Failure to canonicalize input is a very common mistake when implementing validation schemes.
+# Canonicalization is automatic when using the ESAPI Validator, but you can also use the
+# following code to canonicalize data.
+#
+#      ESAPI.Encoder().canonicalize( "%22hello world&#x22;" );
+#  
+# Multiple encoding is when a single encoding format is applied multiple times. Allowing
+# multiple encoding is strongly discouraged.
+Encoder.AllowMultipleEncoding=false
+
+# Mixed encoding is when multiple different encoding formats are applied, or when 
+# multiple formats are nested. Allowing multiple encoding is strongly discouraged.
+Encoder.AllowMixedEncoding=false
+
+# The default list of codecs to apply when canonicalizing untrusted data. The list should include the codecs
+# for all downstream interpreters or decoders. For example, if the data is likely to end up in a URL, HTML, or
+# inside JavaScript, then the list of codecs below is appropriate. The order of the list is not terribly important.
+Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
+
+
+#===========================================================================
+# ESAPI Encryption
+#
+# The ESAPI Encryptor provides basic cryptographic functions with a simplified API.
+# To get started, generate a new key using java -classpath esapi.jar org.owasp.esapi.reference.crypto.JavaEncryptor
+# There is not currently any support for key rotation, so be careful when changing your key and salt as it
+# will invalidate all signed, encrypted, and hashed data.
+#
+# WARNING: Not all combinations of algorithms and key lengths are supported.
+# If you choose to use a key length greater than 128, you MUST download the
+# unlimited strength policy files and install in the lib directory of your JRE/JDK.
+# See http://java.sun.com/javase/downloads/index.jsp for more information.
+#
+# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
+# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
+# possible, these methods should be avoided as they use ECB cipher mode, which in almost
+# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
+# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
+# should only use this compatibility setting if you have persistent data encrypted with
+# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
+# you have decrypted all of your old encrypted data and then re-encrypted it with
+# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
+# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
+# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
+# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
+# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
+# that requires downloading the special jurisdiction policy files mentioned above.)
+#
+#		***** IMPORTANT: Do NOT forget to replace these with your own values! *****
+# To calculate these values, you can run:
+#		java -classpath esapi.jar org.owasp.esapi.reference.crypto.JavaEncryptor
+#
+Encryptor.MasterKey=tzfztf56ftv
+Encryptor.MasterSalt=123456ztrewq
+
+# Provides the default JCE provider that ESAPI will "prefer" for its symmetric
+# encryption and hashing. (That is it will look to this provider first, but it
+# will defer to other providers if the requested algorithm is not implemented
+# by this provider.) If left unset, ESAPI will just use your Java VM's current
+# preferred JCE provider, which is generally set in the file
+# "$JAVA_HOME/jre/lib/security/java.security".
+#
+# The main intent of this is to allow ESAPI symmetric encryption to be
+# used with a FIPS 140-2 compliant crypto-module. For details, see the section
+# "Using ESAPI Symmetric Encryption with FIPS 140-2 Cryptographic Modules" in
+# the ESAPI 2.0 Symmetric Encryption User Guide, at:
+# http://owasp-esapi-java.googlecode.com/svn/trunk/documentation/esapi4java-core-2.0-symmetric-crypto-user-guide.html
+# However, this property also allows you to easily use an alternate JCE provider
+# such as "Bouncy Castle" without having to make changes to "java.security".
+# See Javadoc for SecurityProviderLoader for further details. If you wish to use
+# a provider that is not known to SecurityProviderLoader, you may specify the
+# fully-qualified class name of the JCE provider class that implements
+# java.security.Provider. If the name contains a '.', this is interpreted as
+# a fully-qualified class name that implements java.security.Provider.
+#
+# NOTE: Setting this property has the side-effect of changing it in your application
+#       as well, so if you are using JCE in your application directly rather than
+#       through ESAPI (you wouldn't do that, would you? ;-), it will change the
+#       preferred JCE provider there as well.
+#
+# Default: Keeps the JCE provider set to whatever JVM sets it to.
+Encryptor.PreferredJCEProvider=
+
+# AES is the most widely used and strongest encryption algorithm. This
+# should agree with your Encryptor.CipherTransformation property.
+# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
+# very weak. It is essentially a password-based encryption key, hashed
+# with MD5 around 1K times and then encrypted with the weak DES algorithm
+# (56-bits) using ECB mode and an unspecified padding (it is
+# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
+# "AES/CBC/PKCSPadding". If you want to change these, change them here.
+# Warning: This property does not control the default reference implementation for
+#		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
+#		   in the future.
+# @deprecated
+Encryptor.EncryptionAlgorithm=AES
+#		For ESAPI Java 2.0 - New encrypt / decrypt methods use this.
+Encryptor.CipherTransformation=AES/CBC/PKCS5Padding
+
+# Applies to ESAPI 2.0 and later only!
+# Comma-separated list of cipher modes that provide *BOTH*
+# confidentiality *AND* message authenticity. (NIST refers to such cipher
+# modes as "combined modes" so that's what we shall call them.) If any of these
+# cipher modes are used then no MAC is calculated and stored
+# in the CipherText upon encryption. Likewise, if one of these
+# cipher modes is used with decryption, no attempt will be made
+# to validate the MAC contained in the CipherText object regardless
+# of whether it contains one or not. Since the expectation is that
+# these cipher modes support support message authenticity already,
+# injecting a MAC in the CipherText object would be at best redundant.
+#
+# Note that as of JDK 1.5, the SunJCE provider does not support *any*
+# of these cipher modes. Of these listed, only GCM and CCM are currently
+# NIST approved. YMMV for other JCE providers. E.g., Bouncy Castle supports
+# GCM and CCM with "NoPadding" mode, but not with "PKCS5Padding" or other
+# padding modes.
+Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
+
+# Applies to ESAPI 2.0 and later only!
+# Additional cipher modes allowed for ESAPI 2.0 encryption. These
+# cipher modes are in _addition_ to those specified by the property
+# 'Encryptor.cipher_modes.combined_modes'.
+# Note: We will add support for streaming modes like CFB & OFB once
+# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
+# (probably in ESAPI 2.1).
+# DISCUSS: Better name?
+Encryptor.cipher_modes.additional_allowed=CBC
+
+# 128-bit is almost always sufficient and appears to be more resistant to
+# related key attacks than is 256-bit AES. Use '_' to use default key size
+# for cipher algorithms (where it makes sense because the algorithm supports
+# a variable key size). Key length must agree to what's provided as the
+# cipher transformation, otherwise this will be ignored after logging a
+# warning.
+#
+# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
+Encryptor.EncryptionKeyLength=128
+
+# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) There are two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
+# the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Also, random IVs are generally much more
+# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
+# such as CFB and OFB use a different IV for each encryption with a given key so
+# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
+# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
+# uncomment the Encryptor.fixedIV.
+#
+# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+Encryptor.ChooseIVMethod=random
+# If you choose to use a fixed IV, then you must place a fixed IV here that
+# is known to all others who are sharing your secret key. The format should
+# be a hex string that is the same length as the cipher block size for the
+# cipher algorithm that you are using. The following is an *example* for AES
+# from an AES test vector for AES-128/CBC as described in:
+# NIST Special Publication 800-38A (2001 Edition)
+# "Recommendation for Block Cipher Modes of Operation".
+# (Note that the block size for AES is 16 bytes == 128 bits.)
+#
+Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
+
+# Whether or not CipherText should use a message authentication code (MAC) with it.
+# This prevents an adversary from altering the IV as well as allowing a more
+# fool-proof way of determining the decryption failed because of an incorrect
+# key being supplied. This refers to the "separate" MAC calculated and stored
+# in CipherText, not part of any MAC that is calculated as a result of a
+# "combined mode" cipher mode.
+#
+# If you are using ESAPI with a FIPS 140-2 cryptographic module, you *must* also
+# set this property to false.
+Encryptor.CipherText.useMAC=true
+
+# Whether or not the PlainText object may be overwritten and then marked
+# eligible for garbage collection. If not set, this is still treated as 'true'.
+Encryptor.PlainText.overwrite=true
+
+# Do not use DES except in a legacy situations. 56-bit is way too small key size.
+#Encryptor.EncryptionKeyLength=56
+#Encryptor.EncryptionAlgorithm=DES
+
+# TripleDES is considered strong enough for most purposes.
+#	Note:	There is also a 112-bit version of DESede. Using the 168-bit version
+#			requires downloading the special jurisdiction policy from Sun.
+#Encryptor.EncryptionKeyLength=168
+#Encryptor.EncryptionAlgorithm=DESede
+
+Encryptor.HashAlgorithm=SHA-512
+Encryptor.HashIterations=1024
+Encryptor.DigitalSignatureAlgorithm=SHA1withDSA
+Encryptor.DigitalSignatureKeyLength=1024
+Encryptor.RandomAlgorithm=SHA1PRNG
+Encryptor.CharacterEncoding=UTF-8
+
+# This is the Pseudo Random Function (PRF) that ESAPI's Key Derivation Function
+# (KDF) normally uses. Note this is *only* the PRF used for ESAPI's KDF and
+# *not* what is used for ESAPI's MAC. (Currently, HmacSHA1 is always used for
+# the MAC, mostly to keep the overall size at a minimum.)
+#
+# Currently supported choices for JDK 1.5 and 1.6 are:
+#	HmacSHA1 (160 bits), HmacSHA256 (256 bits), HmacSHA384 (384 bits), and
+#	HmacSHA512 (512 bits).
+# Note that HmacMD5 is *not* supported for the PRF used by the KDF even though
+# the JDKs support it.  See the ESAPI 2.0 Symmetric Encryption User Guide
+# further details.
+Encryptor.KDF.PRF=HmacSHA256
+#===========================================================================
+# ESAPI HttpUtilties
+#
+# The HttpUtilities provide basic protections to HTTP requests and responses. Primarily these methods 
+# protect against malicious data from attackers, such as unprintable characters, escaped characters,
+# and other simple attacks. The HttpUtilities also provides utility methods for dealing with cookies,
+# headers, and CSRF tokens.
+#
+# Default file upload location (remember to escape backslashes with \\)
+HttpUtilities.UploadDir=C:\\ESAPI\\testUpload
+HttpUtilities.UploadTempDir=C:\\temp
+# Force flags on cookies, if you use HttpUtilities to set cookies
+HttpUtilities.ForceHttpOnlySession=false
+HttpUtilities.ForceSecureSession=false
+HttpUtilities.ForceHttpOnlyCookies=true
+HttpUtilities.ForceSecureCookies=true
+# Maximum size of HTTP headers
+HttpUtilities.MaxHeaderSize=4096
+# File upload configuration
+HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.MaxUploadFileBytes=500000000
+# Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
+# container, and any other technologies you may be using. Failure to do this may expose you
+# to Unicode transcoding injection attacks. Use of UTF-8 does not hinder internationalization.
+HttpUtilities.ResponseContentType=text/html; charset=UTF-8
+# This is the name of the cookie used to represent the HTTP session
+# Typically this will be the default "JSESSIONID" 
+HttpUtilities.HttpSessionIdName=JSESSIONID
+
+
+
+#===========================================================================
+# ESAPI Executor
+# CHECKME - Not sure what this is used for, but surely it should be made OS independent.
+Executor.WorkingDirectory=C:\\Windows\\Temp
+Executor.ApprovedExecutables=C:\\Windows\\System32\\cmd.exe,C:\\Windows\\System32\\runas.exe
+
+
+#===========================================================================
+# ESAPI Logging
+# Set the application name if these logs are combined with other applications
+Logger.ApplicationName=ExampleApplication
+# If you use an HTML log viewer that does not properly HTML escape log data, you can set LogEncodingRequired to true
+Logger.LogEncodingRequired=true
+# Determines whether ESAPI should log the application name. This might be clutter in some single-server/single-app environments.
+Logger.LogApplicationName=true
+# Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
+Logger.LogServerIP=true
+# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
+# want to place it in a specific directory.
+Logger.LogFileName=ESAPI_logging_file
+# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
+Logger.MaxLogFileSize=10000000
+
+
+#===========================================================================
+# ESAPI Intrusion Detection
+#
+# Each event has a base to which .count, .interval, and .action are added
+# The IntrusionException will fire if we receive "count" events within "interval" seconds
+# The IntrusionDetector is configurable to take the following actions: log, logout, and disable
+#  (multiple actions separated by commas are allowed e.g. event.test.actions=log,disable
+#
+# Custom Events
+# Names must start with "event." as the base
+# Use IntrusionDetector.addEvent( "test" ) in your code to trigger "event.test" here
+# You can also disable intrusion detection completely by changing
+# the following parameter to true
+#
+IntrusionDetector.Disable=false
+#
+IntrusionDetector.event.test.count=2
+IntrusionDetector.event.test.interval=10
+IntrusionDetector.event.test.actions=disable,log
+
+# Exception Events
+# All EnterpriseSecurityExceptions are registered automatically
+# Call IntrusionDetector.getInstance().addException(e) for Exceptions that do not extend EnterpriseSecurityException
+# Use the fully qualified classname of the exception as the base
+
+# any intrusion is an attack
+IntrusionDetector.org.owasp.esapi.errors.IntrusionException.count=1
+IntrusionDetector.org.owasp.esapi.errors.IntrusionException.interval=1
+IntrusionDetector.org.owasp.esapi.errors.IntrusionException.actions=log,disable,logout
+
+# for test purposes
+# CHECKME: Shouldn't there be something in the property name itself that designates
+#		   that these are for testing???
+IntrusionDetector.org.owasp.esapi.errors.IntegrityException.count=10
+IntrusionDetector.org.owasp.esapi.errors.IntegrityException.interval=5
+IntrusionDetector.org.owasp.esapi.errors.IntegrityException.actions=log,disable,logout
+
+# rapid validation errors indicate scans or attacks in progress
+# org.owasp.esapi.errors.ValidationException.count=10
+# org.owasp.esapi.errors.ValidationException.interval=10
+# org.owasp.esapi.errors.ValidationException.actions=log,logout
+
+# sessions jumping between hosts indicates session hijacking
+IntrusionDetector.org.owasp.esapi.errors.AuthenticationHostException.count=2
+IntrusionDetector.org.owasp.esapi.errors.AuthenticationHostException.interval=10
+IntrusionDetector.org.owasp.esapi.errors.AuthenticationHostException.actions=log,logout
+
+
+#===========================================================================
+# ESAPI Validation
+#
+# The ESAPI Validator works on regular expressions with defined names. You can define names
+# either here, or you may define application specific patterns in a separate file defined below.
+# This allows enterprises to specify both organizational standards as well as application specific
+# validation rules.
+#
+Validator.ConfigurationFile=validation.properties
+
+# Validators used by ESAPI
+Validator.AccountName=^[a-zA-Z0-9]{3,20}$
+Validator.SystemCommand=^[a-zA-Z\\-\\/]{1,64}$
+Validator.RoleName=^[a-z]{1,20}$
+
+#the word TEST below should be changed to your application 
+#name - only relative URL's are supported
+Validator.Redirect=^\\/test.*$
+
+# Global HTTP Validation Rules
+# Values with Base64 encoded data (e.g. encrypted state) will need at least [a-zA-Z0-9\/+=]
+Validator.HTTPScheme=^(http|https)$
+Validator.HTTPServerName=^[a-zA-Z0-9_.\\-]*$
+Validator.HTTPParameterName=^[a-zA-Z0-9_]{1,32}$
+Validator.HTTPParameterValue=^[a-zA-Z0-9.\\-\\/+=@_ ]*$
+Validator.HTTPCookieName=^[a-zA-Z0-9\\-_]{1,32}$
+Validator.HTTPCookieValue=^[a-zA-Z0-9\\-\\/+=_ ]*$
+Validator.HTTPHeaderName=^[a-zA-Z0-9\\-_]{1,32}$
+Validator.HTTPHeaderValue=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
+Validator.HTTPContextPath=^\\/?[a-zA-Z0-9.\\-\\/_]*$
+Validator.HTTPServletPath=^[a-zA-Z0-9.\\-\\/_]*$
+Validator.HTTPPath=^[a-zA-Z0-9.\\-_]*$
+Validator.HTTPQueryString=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ %]*$
+Validator.HTTPURI=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
+Validator.HTTPURL=^.*$
+Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
+
+# Validation of file related input
+Validator.FileName=^[a-zA-Z0-9!@#$%^&{}\\[\\]()_+\\-=,.~'` ]{1,255}$
+Validator.DirectoryName=^[a-zA-Z0-9:/\\\\!@#$%^&{}\\[\\]()_+\\-=,.~'` ]{1,255}$
+
+# Validation of dates. Controls whether or not 'lenient' dates are accepted.
+# See DataFormat.setLenient(boolean flag) for further details.
+Validator.AcceptLenientDates=false

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,50 @@
+# Set root logger level to error
+log4j.rootLogger=error, Console, File
+
+###### Console appender definition #######
+
+# All outputs currently set to be a ConsoleAppender.
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+
+# use log4j NDC to replace %x with tenant domain / username
+log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %x %-5p [%c{3}] [%t] %m%n 
+#log4j.appender.Console.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%c] %m%n
+
+###### File appender definition #######
+log4j.appender.File=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.File.File=share.log
+log4j.appender.File.Append=true
+log4j.appender.File.DatePattern='.'yyyy-MM-dd
+
+# log4j.appender.File.layout=org.apache.log4j.PatternLayout
+# MNT-20203 extend Layout to neutralize logs 
+log4j.appender.File.layout=com.yellresearch.aptr.NewLinePatternLayout
+log4j.appender.File.layout.ConversionPattern=%d{yyyy-MM-dd} %d{ABSOLUTE} %-5p [%c] [%t] %m%n
+
+# Spring
+log4j.logger.org.springframework=warn
+# Turn off Spring remoting warnings that should really be info or debug.
+log4j.logger.org.springframework.remoting.support=error
+log4j.logger.org.springframework.util=error
+
+# MyFaces
+log4j.logger.org.apache.myfaces.util.DebugUtils=info
+log4j.logger.org.apache.myfaces.el.VariableResolverImpl=error
+log4j.logger.org.apache.myfaces.application.jsp.JspViewHandlerImpl=error
+log4j.logger.org.apache.myfaces.taglib=error
+
+# Alfresco
+log4j.logger.org.alfresco=error
+log4j.logger.org.alfresco.config=warn
+log4j.logger.org.alfresco.config.JndiObjectFactoryBean=warn
+log4j.logger.org.alfresco.web=info
+
+# Web Framework
+log4j.logger.org.springframework.extensions.webscripts=info
+log4j.logger.org.springframework.extensions.webscripts.ScriptLogger=warn
+log4j.logger.org.springframework.extensions.webscripts.ScriptDebugger=off
+
+# Freemarker
+# Note the freemarker.runtime logger is used to log non-fatal errors that are handled by Alfresco's retrying transaction handler
+log4j.logger.freemarker.runtime=

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -6,21 +6,41 @@ log4j.rootLogger=error, Console, File
 # All outputs currently set to be a ConsoleAppender.
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-
 # use log4j NDC to replace %x with tenant domain / username
 log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %x %-5p [%c{3}] [%t] %m%n 
 #log4j.appender.Console.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%c] %m%n
 
 ###### File appender definition #######
 log4j.appender.File=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.File.File=share.log
+log4j.appender.File.File=alfresco.log
 log4j.appender.File.Append=true
 log4j.appender.File.DatePattern='.'yyyy-MM-dd
-
 # log4j.appender.File.layout=org.apache.log4j.PatternLayout
-# MNT-20203 extend Layout to neutralize logs 
-log4j.appender.File.layout=com.yellresearch.aptr.NewLinePatternLayout
+# MNT-20199 extend Layout to neutralize logs 
+# LM_2019-01-30
+log4j.appender.File.layout=org.apache.log4j.NewLinePatternLayout
+
 log4j.appender.File.layout.ConversionPattern=%d{yyyy-MM-dd} %d{ABSOLUTE} %-5p [%c] [%t] %m%n
+
+###### Hibernate specific appender definition #######
+#log4j.appender.file=org.apache.log4j.FileAppender
+#log4j.appender.file.File=hibernate.log
+#log4j.appender.file.layout=org.apache.log4j.PatternLayout
+#log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+###### Log level overrides #######
+
+# Commented-in loggers will be exposed as JMX MBeans (refer to org.alfresco.repo.admin.Log4JHierarchyInit)
+# Hence, generally useful loggers should be listed with at least ERROR level to allow simple runtime
+# control of the level via a suitable JMX Console. Also, any other loggers can be added transiently via
+# Log4j addLoggerMBean as long as the logger exists and has been loaded.
+
+# Hibernate
+log4j.logger.org.hibernate=error
+log4j.logger.org.hibernate.util.JDBCExceptionReporter=fatal
+log4j.logger.org.hibernate.event.def.AbstractFlushingEventListener=fatal
+log4j.logger.org.hibernate.type=warn
+log4j.logger.org.hibernate.cfg.SettingsFactory=warn
 
 # Spring
 log4j.logger.org.springframework=warn
@@ -28,23 +48,229 @@ log4j.logger.org.springframework=warn
 log4j.logger.org.springframework.remoting.support=error
 log4j.logger.org.springframework.util=error
 
+# Axis/WSS4J
+log4j.logger.org.apache.axis=info
+log4j.logger.org.apache.ws=info
+
+# CXF
+log4j.logger.org.apache.cxf=error
+
 # MyFaces
 log4j.logger.org.apache.myfaces.util.DebugUtils=info
 log4j.logger.org.apache.myfaces.el.VariableResolverImpl=error
 log4j.logger.org.apache.myfaces.application.jsp.JspViewHandlerImpl=error
 log4j.logger.org.apache.myfaces.taglib=error
 
+# log prepared statement cache activity ###
+log4j.logger.org.hibernate.ps.PreparedStatementCache=info
+
 # Alfresco
 log4j.logger.org.alfresco=error
+log4j.logger.org.alfresco.repo.admin=info
+log4j.logger.org.alfresco.repo.transaction=warn
+log4j.logger.org.alfresco.repo.cache.TransactionalCache=warn
+log4j.logger.org.alfresco.repo.model.filefolder=warn
+log4j.logger.org.alfresco.repo.tenant=info
 log4j.logger.org.alfresco.config=warn
 log4j.logger.org.alfresco.config.JndiObjectFactoryBean=warn
+log4j.logger.org.alfresco.config.JBossEnabledWebApplicationContext=warn
+log4j.logger.org.alfresco.repo.management.subsystems=warn
+log4j.logger.org.alfresco.repo.management.subsystems.ChildApplicationContextFactory=info
+log4j.logger.org.alfresco.repo.management.subsystems.ChildApplicationContextFactory$ChildApplicationContext=warn
+log4j.logger.org.alfresco.repo.security.sync=info
+log4j.logger.org.alfresco.repo.security.person=info
+
+log4j.logger.org.alfresco.sample=info
 log4j.logger.org.alfresco.web=info
+#log4j.logger.org.alfresco.web.app.AlfrescoNavigationHandler=debug
+#log4j.logger.org.alfresco.web.ui.repo.component.UIActions=debug
+#log4j.logger.org.alfresco.web.ui.repo.tag.PageTag=debug
+#log4j.logger.org.alfresco.web.bean.clipboard=debug
+log4j.logger.org.alfresco.service.descriptor.DescriptorService=info
+#log4j.logger.org.alfresco.web.page=debug
+
+log4j.logger.org.alfresco.repo.importer.ImporterBootstrap=error
+#log4j.logger.org.alfresco.repo.importer.ImporterBootstrap=info
+
+log4j.logger.org.alfresco.repo.admin.patch.PatchExecuter=info
+log4j.logger.org.alfresco.repo.domain.patch.ibatis.PatchDAOImpl=info
+
+# Specific patches
+log4j.logger.org.alfresco.repo.admin.patch.impl.DeploymentMigrationPatch=info
+log4j.logger.org.alfresco.repo.version.VersionMigrator=info
+
+log4j.logger.org.alfresco.repo.module.ModuleServiceImpl=info
+log4j.logger.org.alfresco.repo.domain.schema.SchemaBootstrap=info
+log4j.logger.org.alfresco.repo.admin.ConfigurationChecker=info
+log4j.logger.org.alfresco.repo.node.index.AbstractReindexComponent=warn
+log4j.logger.org.alfresco.repo.node.index.IndexTransactionTracker=warn
+log4j.logger.org.alfresco.repo.node.index.FullIndexRecoveryComponent=info
+#log4j.logger.org.alfresco.repo.node.db.hibernate.HibernateNodeDaoServiceImpl=warn
+log4j.logger.org.alfresco.repo.domain.hibernate.DirtySessionMethodInterceptor=warn
+log4j.logger.org.alfresco.repo.transaction.RetryingTransactionHelper=warn
+log4j.logger.org.alfresco.util.transaction.SpringAwareUserTransaction.trace=warn
+log4j.logger.org.alfresco.util.AbstractTriggerBean=warn
+log4j.logger.org.alfresco.enterprise.repo.cluster=info
+log4j.logger.org.alfresco.repo.version.Version2ServiceImpl=warn
+
+#log4j.logger.org.alfresco.web.app.DebugPhaseListener=debug
+log4j.logger.org.alfresco.repo.node.db.NodeStringLengthWorker=info
+
+log4j.logger.org.alfresco.repo.workflow=info
+
+# FTP server debugging
+log4j.logger.org.alfresco.ftp.protocol=error
+#log4j.logger.org.alfresco.ftp.server=debug
+
+# WebDAV debugging
+#log4j.logger.org.alfresco.webdav.protocol=debug
+log4j.logger.org.alfresco.webdav.protocol=info
+
+# Kerberos servlet filters
+#log4j.logger.org.alfresco.web.app.servlet.KerberosAuthenticationFilter=debug
+#log4j.logger.org.alfresco.repo.webdav.auth.KerberosAuthenticationFilter=debug
+
+# File servers
+log4j.logger.org.alfresco.fileserver=warn
+
+# Repo filesystem debug logging
+#log4j.logger.org.alfresco.filesys.repo.ContentDiskDriver=debug
+
+# Integrity message threshold - if 'failOnViolation' is off, then WARNINGS are generated
+log4j.logger.org.alfresco.repo.node.integrity=ERROR
+
+# Authentication
+log4j.logger.org.alfresco.filesys.auth.ftp=warn
+log4j.logger.org.alfresco.ftp.protocol.auth=warn
+log4j.logger.org.alfresco.repo.webdav.auth=warn
+log4j.logger.org.alfresco.repo.web.auth=warn
+log4j.logger.org.alfresco.web.app.servlet=warn
+# Used also for brute force attack detection
+log4j.logger.org.alfresco.repo.security.authentication=warn
+
+# Indexer debugging
+log4j.logger.org.alfresco.repo.search.Indexer=error
+#log4j.logger.org.alfresco.repo.search.Indexer=debug
+
+log4j.logger.org.alfresco.repo.search.impl.lucene.index=error
+log4j.logger.org.alfresco.repo.search.impl.lucene.fts.FullTextSearchIndexerImpl=warn
+#log4j.logger.org.alfresco.repo.search.impl.lucene.index=DEBUG
+
+# Audit debugging
+# log4j.logger.org.alfresco.repo.audit=DEBUG
+# log4j.logger.org.alfresco.repo.audit.model=DEBUG
+
+# Property sheet and modelling debugging
+# change to error to hide the warnings about missing properties and associations
+log4j.logger.alfresco.missingProperties=warn
+
+# Dictionary/Model debugging
+log4j.logger.org.alfresco.repo.dictionary=warn
+log4j.logger.org.alfresco.repo.dictionary.types.period=warn
+
+# Virtualization Server Registry
+log4j.logger.org.alfresco.mbeans.VirtServerRegistry=error
+
+# Spring context runtime property setter
+log4j.logger.org.alfresco.util.RuntimeSystemPropertiesSetter=info
+
+# Debugging options for clustering
+log4j.logger.org.alfresco.repo.content.ReplicatingContentStore=error
+log4j.logger.org.alfresco.repo.content.replication=error
+
+#log4j.logger.org.alfresco.repo.deploy.DeploymentServiceImpl=debug
+
+# Activity service
+log4j.logger.org.alfresco.repo.activities=warn
+
+# User usage tracking
+log4j.logger.org.alfresco.repo.usage=info
+
+# Sharepoint
+log4j.logger.org.alfresco.module.vti=info
+
+# Forms Engine
+log4j.logger.org.alfresco.web.config.forms=info
+log4j.logger.org.alfresco.web.scripts.forms=info
+
+# CMIS
+log4j.logger.org.alfresco.opencmis=error
+log4j.logger.org.alfresco.opencmis.AlfrescoCmisServiceInterceptor=error
+log4j.logger.org.alfresco.cmis=error
+log4j.logger.org.alfresco.cmis.dictionary=warn
+log4j.logger.org.apache.chemistry.opencmis=info
+log4j.logger.org.apache.chemistry.opencmis.server.impl.browser.CmisBrowserBindingServlet=OFF
+log4j.logger.org.apache.chemistry.opencmis.server.impl.atompub.CmisAtomPubServlet=OFF
+
+# IMAP
+log4j.logger.org.alfresco.repo.imap=info
+
+# JBPM
+# Note: non-fatal errors (eg. logged during job execution) should be handled by Alfresco's retrying transaction handler 
+log4j.logger.org.jbpm.graph.def.GraphElement=fatal
+
+#log4j.logger.org.alfresco.repo.googledocs=debug
+
+###### Scripting #######
 
 # Web Framework
 log4j.logger.org.springframework.extensions.webscripts=info
 log4j.logger.org.springframework.extensions.webscripts.ScriptLogger=warn
 log4j.logger.org.springframework.extensions.webscripts.ScriptDebugger=off
 
+# Repository
+log4j.logger.org.alfresco.repo.web.scripts=warn
+log4j.logger.org.alfresco.repo.web.scripts.BaseWebScriptTest=info
+log4j.logger.org.alfresco.repo.web.scripts.AlfrescoRhinoScriptDebugger=off
+log4j.logger.org.alfresco.repo.jscript=error
+log4j.logger.org.alfresco.repo.jscript.ScriptLogger=warn
+log4j.logger.org.alfresco.repo.cmis.rest.CMISTest=info
+
+log4j.logger.org.alfresco.repo.domain.schema.script.ScriptBundleExecutorImpl=off
+log4j.logger.org.alfresco.repo.domain.schema.script.ScriptExecutorImpl=info
+
+log4j.logger.org.alfresco.repo.search.impl.solr.facet.SolrFacetServiceImpl=info
+
+# Bulk Filesystem Import Tool
+log4j.logger.org.alfresco.repo.bulkimport=warn
+
 # Freemarker
 # Note the freemarker.runtime logger is used to log non-fatal errors that are handled by Alfresco's retrying transaction handler
 log4j.logger.freemarker.runtime=
+
+# Metadata extraction
+log4j.logger.org.alfresco.repo.content.metadata.AbstractMappingMetadataExtracter=warn
+
+# Reduces PDFont error level due to ALF-7105
+log4j.logger.org.apache.pdfbox.pdmodel.font.PDSimpleFont=fatal
+log4j.logger.org.apache.pdfbox.pdmodel.font.PDFont=fatal
+log4j.logger.org.apache.pdfbox.pdmodel.font.PDCIDFont=fatal
+
+# no index support
+log4j.logger.org.alfresco.repo.search.impl.noindex.NoIndexIndexer=fatal
+log4j.logger.org.alfresco.repo.search.impl.noindex.NoIndexSearchService=fatal
+
+# lucene index warnings
+log4j.logger.org.alfresco.repo.search.impl.lucene.index.IndexInfo=warn
+
+# Warn about RMI socket bind retries.
+log4j.logger.org.alfresco.util.remote.server.socket.HostConfigurableSocketFactory=warn
+
+log4j.logger.org.alfresco.repo.usage.RepoUsageMonitor=info
+
+# Authorization
+log4j.logger.org.alfresco.enterprise.repo.authorization.AuthorizationService=info
+log4j.logger.org.alfresco.enterprise.repo.authorization.AuthorizationsConsistencyMonitor=warn
+
+# HeartBeat
+log4j.logger.org.alfresco.heartbeat=info
+
+# Transformations
+#log4j.logger.org.alfresco.repo.content.transform.TransformerDebug=debug
+log4j.logger.org.alfresco.repo.content.transform.JodContentTransformer=info
+log4j.logger.org.alfresco.repo.content.transform.magick.ImageMagickContentTransformerWorker=info
+log4j.logger.org.alfresco.repo.content.transform.pdfrenderer.AlfrescoPdfRendererContentTransformerWorker=info
+log4j.logger.org.alfresco.repo.content.transform.TikaPoweredContentTransformer=info
+
+# Repository probes
+log4j.logger.org.alfresco.rest.api.probes.ProbeEntityResource=info


### PR DESCRIPTION
A function call could result in a log forging attack. Writing untrusted data into a log file allows an attacker to forge log entries or inject malicious content into log files. Corrupted log files can be used to cover an attacker's tracks or as a delivery mechanism for an attack on a log viewing or processing utility. For example, if a web administrator uses a browser-based utility to review logs, a cross-site scripting attack might be possible.

* imported ESAPI library
* added ESAPI.properties for configuration
* added a java class that extends PatternLayout to sanitize log message before writing to log file