### PR TITLE
MNT-20201 Session Fixation CWE ID 384

### DIFF
--- a/src/main/java/org/alfresco/web/app/servlet/WebScriptSSOAuthenticationFilter.java
+++ b/src/main/java/org/alfresco/web/app/servlet/WebScriptSSOAuthenticationFilter.java
@@ -102,8 +102,8 @@ public class WebScriptSSOAuthenticationFilter extends BaseAuthenticationFilter i
         String pathInfo = requestURI.substring((req.getContextPath() + req.getServletPath()).length());
         
         if (getLogger().isDebugEnabled())
-            getLogger().debug("Processing request: " + requestURI + " SID:" +
-                    (req.getSession(false) != null ? req.getSession().getId() : null));
+        	// MNT-20201 (LM-190213): display current session id or new one if not exist
+        	getLogger().debug("Processing request: " + requestURI + " SID:" + req.getSession().getId());
         
         Match match = container.getRegistry().findWebScript(req.getMethod(), URLDecoder.decode(pathInfo));
         if (match != null && match.getWebScript() != null)


### PR DESCRIPTION
According to VeraCode:

> The application never invalidates user sessions, which can lead to session fixation attacks. As a result, the session identifier stays the same before, during, and after a user has logged in or out. An attacker may attempt to force a user into using a specific session identifier, then hijack the session once the user has logged in.
> 
> Instances found via Static Scan
> - alfresco.war/alfresco-enterprise-remote-api-6.25.jar | .../WebScriptSSOAuthenticationFilter.java
> 
> Fix
> - use different API to retrieve the session object, which handle new session creation if none exists.

Our Analysis:
1. The main substance of the PenTest is not relevant, as Session invalidation is already handled during user login and logout in AbstractLoginController class; no change required there.
2. The flagged class (WebScriptSSOAuthenticationFilter) is a low risk attack vector, requiring the logs to be compromised to obtain the session id. Even still, there is an opportunity to enhance the logging code, which we have proposed in this PR.