### PR TITLE
Fix issue in access to Admin Console via HTTP Basic for admins other than literal "admin"

### DIFF
--- a/src/main/java/org/alfresco/repo/web/scripts/servlet/BasicHttpAuthenticatorFactory.java
+++ b/src/main/java/org/alfresco/repo/web/scripts/servlet/BasicHttpAuthenticatorFactory.java
@@ -324,7 +324,7 @@ public class BasicHttpAuthenticatorFactory implements ServletAuthenticatorFactor
                 return true;
             }
             // then check the admin group
-            return authorityService.isAdminAuthority(auth.getUserName());
+            return AuthenticationUtil.runAsSystem(() -> authorityService.isAdminAuthority(auth.getUserName()));
         }
     }
 


### PR DESCRIPTION
This PR fixes a small issue in the basic HTTP authenticator introduced with 6.1, affecting access of administrators to the Admin Console via HTTP Basic authentication in certain constellations (encountered during experimentation with Keycloak integration). If the user accessing the Admin Console is not the literal "admin" user, fallback code will check if the user is contained in the admin group. The service call for this check requires a valid security context, but at this stage there likely is no such context. The call should always be performed in a runAsSystem scope to be sure.

Log excerpt:
```
2019-05-10 15:13:07,828 ERROR [org.springframework.extensions.webscripts.AbstractRuntime] [catalina-exec-2] Exception from executeScript: A valid SecureContext was not provided in the RequestContext
net.sf.acegisecurity.AuthenticationCredentialsNotFoundException: A valid SecureContext was not provided in the RequestContext
	at net.sf.acegisecurity.intercept.AbstractSecurityInterceptor.credentialsNotFound(AbstractSecurityInterceptor.java:481)
	at net.sf.acegisecurity.intercept.AbstractSecurityInterceptor.beforeInvocation(AbstractSecurityInterceptor.java:359)
	at net.sf.acegisecurity.intercept.method.aopalliance.MethodSecurityInterceptor.invoke(MethodSecurityInterceptor.java:77)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.alfresco.repo.security.permissions.impl.ExceptionTranslatorMethodInterceptor.invoke(ExceptionTranslatorMethodInterceptor.java:53)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.alfresco.repo.audit.AuditMethodInterceptor.invoke(AuditMethodInterceptor.java:166)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:294)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:98)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212)
	at com.sun.proxy.$Proxy81.isAdminAuthority(Unknown Source)
	at org.alfresco.repo.web.scripts.servlet.BasicHttpAuthenticatorFactory$BasicHttpAuthenticator.isBasicAuthHeaderPresentForAdmin(BasicHttpAuthenticatorFactory.java:327)
	at org.alfresco.repo.web.scripts.servlet.RemoteUserAuthenticatorFactory$RemoteUserAuthenticator.authenticate(RemoteUserAuthenticatorFactory.java:155)
	at org.alfresco.repo.web.scripts.RepositoryContainer$2.execute(RepositoryContainer.java:385)
	at org.alfresco.repo.web.scripts.RepositoryContainer$2.execute(RepositoryContainer.java:382)
	at org.alfresco.repo.transaction.RetryingTransactionHelper.doInTransaction(RetryingTransactionHelper.java:450)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScriptInternal(RepositoryContainer.java:424)
	at org.alfresco.repo.web.scripts.RepositoryContainer.executeScript(RepositoryContainer.java:308)
	at de.acosix.alfresco.utility.repo.web.scripts.TenantExtensibilityContainer.executeScript(TenantExtensibilityContainer.java:203)
```