### PR TITLE
POST multipart children with aspectnames parameter

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/RenditionsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/RenditionsImpl.java
@@ -333,7 +333,7 @@ public class RenditionsImpl implements Renditions, ResourceLoaderAware
         for (Rendition rendition : renditions)
         {
             String name = getName(rendition);
-            Set<String> requestedRenditions = NodesImpl.getRequestedRenditions(name);
+            Set<String> requestedRenditions = NodesImpl.splitCommaSeparatedString(name);
             if (requestedRenditions == null)
             {
                 renditionNames.add(null);

--- a/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -2638,6 +2638,28 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
 
         // Upload with multipart with missing boundary e.g. multipart/form-data; boundary=7cgH0q1hSgrlmU7tUe8kGSWT4Un6aRH
         post(getNodeChildrenUrl(Nodes.PATH_MY), reqBody.getBody(), null, "multipart/form-data", 415);
+
+        // set aspect which doesn't exist
+        List<String> aspects = new ArrayList<>();
+        aspects.add("hackathon:2019");
+        aspects.add("papi:dessertable");
+        multiPartBuilder.setAspects(aspects);
+        reqBody = multiPartBuilder.build();
+        post(getNodeChildrenUrl(Nodes.PATH_MY), reqBody.getBody(), null, reqBody.getContentType(), 400);
+
+        // set aspect which exist
+        aspects = new ArrayList<>();
+        aspects.add("papi:dessertable");
+        multiPartBuilder.setAspects(aspects);
+        reqBody = multiPartBuilder.build();
+        HttpResponse response = post(getNodeChildrenUrl(Nodes.PATH_MY), reqBody.getBody(), null, reqBody.getContentType(), 201);
+
+        Document document = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        // Check the upload response
+        assertEquals("quick-1.txt", document.getName());
+        assertNotNull(document.getAspectNames());
+        assertTrue("Doesn't contains papi:dessertable in aspects", document.getAspectNames().contains("papi:dessertable"));
     }
 
 

--- a/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
+++ b/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
@@ -278,7 +278,7 @@ public class MultiPartBuilder
         addPartIfNotNull(parts, "updatenoderef", updateNodeRef);
         addPartIfNotNull(parts, "description", description);
         addPartIfNotNull(parts, "contenttype", contentTypeQNameStr);
-        addPartIfNotNull(parts, "aspects", getCommaSeparated(aspects));
+        addPartIfNotNull(parts, "aspectnames", getCommaSeparated(aspects));
         addPartIfNotNull(parts, "majorversion", majorVersion);
         addPartIfNotNull(parts, "overwrite", overwrite);
         addPartIfNotNull(parts, "autorename", autoRename);


### PR DESCRIPTION
10 May Alfresco Hackathon. Add aspectnames parameter to POST multipart children endpoint. Add unit test.
Allow aspectnames as parameter when using multipart https://api-explorer.alfresco.com/api-explorer/#!/nodes/createNode.