### PR TITLE
REPO-4303 Service Pack: MNT-20436

### DIFF
--- a/src/main/java/org/alfresco/rest/api/Nodes.java
+++ b/src/main/java/org/alfresco/rest/api/Nodes.java
@@ -343,6 +343,11 @@ public interface Nodes
      * @param exclusions
      */
     void updateCustomAspects(NodeRef nodeRef, List<String> aspectNames, List<QName> exclusions);
+
+    void validateAspects(List<String> aspectNames, List<String> excludedNS, List<QName> excludedAspects);
+
+    void validateProperties(Map<String, Object> properties, List<String> excludedNS, List<QName> excludedProperties);
+
     
     /**
      * API Constants - query parameters, etc

--- a/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -1170,7 +1170,6 @@ public class NodesImpl implements Nodes
                 throw new InvalidArgumentException("Unknown property: " + propName);
             }
         }
-        nodeProps.keySet().removeAll(AuditablePropertiesEntity.getAuditablePropertyQNames());
         return nodeProps;
     }
     
@@ -1754,6 +1753,8 @@ public class NodesImpl implements Nodes
         {
             throw new InvalidArgumentException("Unexpected id when trying to create a new node: "+nodeInfo.getNodeRef().getId());
         }
+        validateAspects(nodeInfo.getAspectNames(), EXCLUDED_NS, EXCLUDED_ASPECTS);
+        validateProperties(nodeInfo.getProperties(), EXCLUDED_NS,  Arrays.asList());
 
         // check that requested parent node exists and it's type is a (sub-)type of folder
         NodeRef parentNodeRef = validateOrLookupNode(parentFolderNodeId, null);
@@ -2245,6 +2246,9 @@ public class NodesImpl implements Nodes
     
     protected NodeRef updateNodeImpl(String nodeId, Node nodeInfo, Parameters parameters)
     {
+        validateAspects(nodeInfo.getAspectNames(), EXCLUDED_NS, EXCLUDED_ASPECTS);
+        validateProperties(nodeInfo.getProperties(), EXCLUDED_NS,  Arrays.asList());
+
         final NodeRef nodeRef = validateOrLookupNode(nodeId, null);
 
         QName nodeTypeQName = getNodeType(nodeRef);
@@ -2952,6 +2956,7 @@ public class NodesImpl implements Nodes
         final QName assocTypeQName = ContentModel.ASSOC_CONTAINS;
         final Set<String> renditions = getRequestedRenditions(renditionNames);
 
+        validateProperties(qnameStrProps, EXCLUDED_NS,  Arrays.asList());
         try
         {
             // Map the given properties, if any.
@@ -3388,7 +3393,42 @@ public class NodesImpl implements Nodes
         }
         return false;
     }
-    
+
+    public void validateAspects(List<String> aspectNames, List<String> excludedNS, List<QName> excludedAspects)
+    {
+        if (aspectNames != null && excludedNS != null && excludedAspects != null)
+        {
+            Set<QName> aspects = mapToNodeAspects(aspectNames);
+            aspects.forEach(aspect -> {
+                if (excludedNS != null && excludedNS.contains(aspect.getNamespaceURI()))
+                {
+                    throw new IllegalArgumentException("NameSpace cannot be used by API: " + aspect.toPrefixString());
+                }
+                if (excludedAspects != null && excludedAspects.contains(aspect))
+                {
+                    throw new IllegalArgumentException("Cannot be used by API: " + aspect.toPrefixString());
+                }
+            });
+        }
+    }
+
+    public void validateProperties(Map<String, Object> properties, List<String> excludedNS, List<QName> excludedProperties)
+    {
+        if (properties != null)
+        {
+            Map<QName, Serializable> nodeProps = mapToNodeProperties(properties);
+            nodeProps.keySet().forEach(property -> {
+                if ((excludedNS != null && excludedNS.contains(property.getNamespaceURI())))
+                {
+                    throw new IllegalArgumentException("NameSpace cannot be used by API: " + property.toPrefixString());
+                }
+                if ((excludedProperties != null && excludedProperties.contains(property)) || AuditablePropertiesEntity.getAuditablePropertyQNames().contains(property))
+                {
+                    throw new IllegalArgumentException("Cannot be used by API: " + property.toPrefixString());
+                }
+            });
+        }
+    }
 
     /**
      * @author Jamal Kaabi-Mofrad

--- a/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -56,6 +56,7 @@ import org.alfresco.repo.action.executer.ContentMetadataExtracter;
 import org.alfresco.repo.activities.ActivityType;
 import org.alfresco.repo.content.ContentLimitViolationException;
 import org.alfresco.repo.content.MimetypeMap;
+import org.alfresco.repo.domain.node.AuditablePropertiesEntity;
 import org.alfresco.repo.lock.mem.Lifetime;
 import org.alfresco.repo.model.Repository;
 import org.alfresco.repo.model.filefolder.FileFolderServiceImpl;
@@ -1169,7 +1170,7 @@ public class NodesImpl implements Nodes
                 throw new InvalidArgumentException("Unknown property: " + propName);
             }
         }
-
+        nodeProps.keySet().removeAll(AuditablePropertiesEntity.getAuditablePropertyQNames());
         return nodeProps;
     }
     

--- a/src/main/java/org/alfresco/rest/api/impl/PeopleImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/PeopleImpl.java
@@ -647,7 +647,8 @@ public class PeopleImpl implements People
         checkRequiredField("password", person.getPassword());
 
         validateUsername(person.getUserName());
-        validateNamespaces(person.getAspectNames(), person.getProperties());
+        nodes.validateAspects(person.getAspectNames(), EXCLUDED_NS, EXCLUDED_ASPECTS);
+        nodes.validateProperties(person.getProperties(), EXCLUDED_NS, EXCLUDED_PROPS);
     }
 
     private void validateUsername(String username)
@@ -671,33 +672,6 @@ public class PeopleImpl implements People
             {
                 throw new IllegalArgumentException("Username cannot start with the reserved prefix '"+prefix+"'.");
             }
-        }
-    }
-
-    private void validateNamespaces(List<String> aspectNames, Map<String, Object> properties)
-    {
-        if (aspectNames != null)
-        {
-            Set<QName> aspects = nodes.mapToNodeAspects(aspectNames);
-            aspects.forEach(aspect ->
-            {
-                if (EXCLUDED_NS.contains(aspect.getNamespaceURI()))
-                {
-                    throw new IllegalArgumentException("Namespace cannot be used by People API: "+aspect.toPrefixString());
-                }
-            });
-        }
-        
-        if (properties != null)
-        {
-            Map<QName, Serializable> nodeProps = nodes.mapToNodeProperties(properties);
-            nodeProps.keySet().forEach(qname ->
-            {
-                if (EXCLUDED_NS.contains(qname.getNamespaceURI()))
-                {
-                    throw new IllegalArgumentException("Namespace cannot be used by People API: "+qname.toPrefixString());
-                }
-            });
         }
     }
 
@@ -794,7 +768,8 @@ public class PeopleImpl implements People
 
     private void validateUpdatePersonData(Person person)
     {
-        validateNamespaces(person.getAspectNames(), person.getProperties());
+        nodes.validateAspects(person.getAspectNames(), EXCLUDED_NS, EXCLUDED_ASPECTS);
+        nodes.validateProperties(person.getProperties(), EXCLUDED_NS, EXCLUDED_PROPS);
         
         if (person.wasSet(ContentModel.PROP_FIRSTNAME))
         {


### PR DESCRIPTION
REPO-4303
Service Pack: MNT-20436 "POST /nodes/{nodeId}/children" RestAPI does not create a node without having a mandatory value object, but it outputs the 201 successful response