### PR TITLE
REPO-4794 - Remove com.benfante:JSlideShare library from alfresco-rep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+	    <exclusions>
+                <exclusion>
+                    <groupId>com.benfante</groupId>
+                    <artifactId>JSlideShare</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…ository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

