### PR TITLE
REPO-4795 - Remove commons-discovery:commons-discovery library from a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+	    <exclusions>
+	         <exclusion>
+	              <groupId>commons-discovery</groupId>
+	              <artifactId>commons-discovery</artifactId>
+	         </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…lfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

