### PR TITLE
REPO-4801 - Remove library org.springframework:spring-orm from alfres…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+	       <exclusion>
+	          <groupId>org.springframework</groupId>
+	          <artifactId>spring-orm</artifactId>
+	       </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…co-repository
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

