### PR TITLE
REPO-4803 - Remove library net.java.dev.stax-utils:stax-utils from al…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.stax-utils</groupId>
+                    <artifactId>stax-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…fresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

