### PR TITLE
REPO-4804 - Remove library org.apache.pdfbox:fontbox from alfresco-re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.pdfbox</artifactId>
+                    <groupId>fontbox</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…pository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

