### PR TITLE
REPO-4806 - Remove library org.bouncycastle:bcmail-jdk15on from alfre…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.bouncycastle</artifactId>
+                    <groupId>bcmail-jdk15on</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…sco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

