### PR TITLE
REPO-4808 - Remove library com.google.gdata:gdata-docs-meta-3.0 from …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+       		<exclusion>
+            		<artifactId>com.google.gdata</artifactId>
+                    	<groupId>gdata-docs-meta-3.0</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

