### PR TITLE
REPO-4811 - Remove library org.apache.ws.xmlschema:xmlschema-core fro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.ws.xmlschema</artifactId>
+                    <groupId>xmlschema-core</groupId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…m alfresco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

