### PR TITLE
REPO-4812 - Remove library org.apache.commons:commons-email from alfr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.commons</artifactId>
+                    <groupId>commons-email</groupId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
@@ -164,11 +170,6 @@
             <version>1.7</version>
         </dependency>
         <!-- newer version, see REPO-3133 -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.5</version>
-        </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webscripts</artifactId>


### PR DESCRIPTION
…esco-repository and alfresco-remote-api project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

