### PR TITLE
REPO-4813 - Remove library org.livetribe:livetribe-jsr223 from alfres…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.livetribe</artifactId>
+                    <groupId>livetribe-jsr223</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…co-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

