### PR TITLE
REPO-4816 - Remove library edu.ucar:netcdf from alfresco-repository p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>edu.ucar</artifactId>
+                    <groupId>netcdf</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>


### PR DESCRIPTION
…roject
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

