### PR TITLE
REPO-4819 - Remove library com.rometools:rome from alfresco-remote-ap…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,6 @@
             <artifactId>jaxrpc-api</artifactId>
             <version>1.1</version>
         </dependency>
-        <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome</artifactId>
-            <version>1.12.2</version>
-        </dependency>
-
         <!-- This is needed at runtime by Web Client, so not really a test dependency -->
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>


### PR DESCRIPTION
…i project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

