### PR TITLE
REPO-4896 - Remove library org.alfresco.cmis.client:alfresco-opencmis…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,6 @@
             <version>${dependency.webscripts.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.alfresco.cmis.client</groupId>
-            <artifactId>alfresco-opencmis-extension</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ws.xmlschema</groupId>
             <artifactId>xmlschema-core</artifactId>
              <version>2.2.4</version>
@@ -279,6 +274,12 @@
             <version>8.2.0.v20160908</version>
             <scope>test</scope> 
         </dependency>
+        <dependency>
+            <groupId>org.alfresco.cmis.client</groupId>
+            <artifactId>alfresco-opencmis-extension</artifactId>
+            <version>1.1</version>
+            <scope>test</scope> 
+        </dependency>        
     </dependencies>
     <profiles>
          <!-- Profiles to extract the alfresco-pdf-renderer -->


### PR DESCRIPTION
…-extension from alfresco-remote-api
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.