### PR TITLE
REPO-4812 - Remove library org.apache.commons:commons-email from alfr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,6 @@
         </dependency>
         <!-- newer version, see REPO-3133 -->
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webscripts</artifactId>
             <version>${dependency.webscripts.version}</version>


### PR DESCRIPTION
…esco-repository project
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.