### PR TITLE
MNT-19292 - Add OpenJDK as a Supported Platform for ACS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,21 @@
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${dependency.jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-xjc</artifactId>
+                <version>2.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Hi.

I fix the bug below.

- [[REPO-3550]](https://issues.alfresco.com/jira/browse/REPO-3550) JDK10: Compilation of repository and remote-api throw a warning

But the issue status is "Duplicate" and another issue is "in Progress". So I prefixed this issue number.

- [[MNT-19292]](https://issues.alfresco.com/jira/browse/MNT-19292)  Add OpenJDK as a Supported Platform for ACS

To modify the source code, we refer to the following articles:

1. [JEP 320](https://openjdk.java.net/jeps/320): Remove the Java EE and CORBA Modules
2. [Migrating to JDK 9](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-7744EF96-5899-4FB2-B34E-86D49B2E89B6)

How about this?