### PR TITLE
[REPO-5239] - Added filter by displayName to /groups endpoint

### DIFF
--- a/src/main/java/org/alfresco/rest/api/impl/GroupsImpl.java
+++ b/src/main/java/org/alfresco/rest/api/impl/GroupsImpl.java
@@ -74,6 +74,7 @@ import org.alfresco.service.cmr.security.AuthorityType;
 import org.alfresco.service.cmr.security.PermissionService;
 import org.alfresco.util.AlfrescoCollator;
 import org.alfresco.util.Pair;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.extensions.surf.util.I18NUtil;
 
 /**
@@ -86,6 +87,7 @@ public class GroupsImpl implements Groups
     private static final int MAX_ZONES = 1;
     private static final int MAX_DISPLAY_NAMES = 1;
     private static final String DISPLAY_NAME = "displayName";
+    private static final String ZONE = "zone";
     private static final String AUTHORITY_NAME = "authorityName";
     private static final String ERR_MSG_MODIFY_FIXED_AUTHORITY = "Trying to modify a fixed authority";
 
@@ -182,46 +184,20 @@ public class GroupsImpl implements Groups
 
     public CollectionWithPagingInfo<Group> getGroups(final Parameters parameters)
     {
-        final List<String> includeParam = parameters.getInclude();
-
         Paging paging = parameters.getPaging();
 
         // Retrieve sort column. This is limited for now to sort column due to
         // v0 api implementation. Should be improved in the future.
         Pair<String, Boolean> sortProp = getGroupsSortProp(parameters);
-
         // Parse where clause properties.
-        Query q = parameters.getQuery();
-        Boolean isRootParam = null;
-        String zoneFilter = null;
-        String displayNameFilter = null;
-        if (q != null)
-        {
-            GroupsQueryWalker propertyWalker = new GroupsQueryWalker();
-            QueryHelper.walk(q, propertyWalker);
-
-            isRootParam = propertyWalker.getIsRoot();
-            List<String> zonesParam = propertyWalker.getZones();
-            List<String> displayNamesParam = propertyWalker.getDisplayNames();
-            if (zonesParam != null)
-            {
-                validateZonesParam(zonesParam);
-                zoneFilter = zonesParam.get(0);
-            }
-            if (displayNamesParam != null)
-            {
-                validateDisplayNamesParam(displayNamesParam);
-                displayNameFilter = displayNamesParam.get(0);
-            }
-        }
-
+        GroupsFilter groupsFilters = getGroupsFilterFromQueryParameters(parameters.getQuery());
         final AuthorityType authorityType = AuthorityType.GROUP;
         final Set<String> rootAuthorities = getAllRootAuthorities(authorityType);
 
         PagingResults<AuthorityInfo> pagingResult;
         try
         {
-            pagingResult = getAuthoritiesInfo(authorityType, isRootParam, zoneFilter, displayNameFilter, rootAuthorities, sortProp, paging);
+            pagingResult = getAuthoritiesInfo(authorityType, groupsFilters, rootAuthorities, sortProp, paging);
         }
         catch (UnknownAuthorityException e)
         {
@@ -229,9 +205,15 @@ public class GroupsImpl implements Groups
             pagingResult = new EmptyPagingResults<>();
         }
 
-        // Create response.
-        final List<AuthorityInfo> page = pagingResult.getPage();
+        List<Group> groups = createGroupsResponse(pagingResult.getPage(), parameters.getInclude(), rootAuthorities);
+
         int totalItems = pagingResult.getTotalResultCount().getFirst();
+
+        return CollectionWithPagingInfo.asPaged(paging, groups, pagingResult.hasMoreItems(), totalItems);
+    }
+    
+    private List<Group> createGroupsResponse(final List<AuthorityInfo> page, final List<String> includeParam, final Set<String> rootAuthorities)
+    {
         List<Group> groups = new AbstractList<Group>()
         {
             @Override
@@ -247,46 +229,58 @@ public class GroupsImpl implements Groups
                 return page.size();
             }
         };
-
-        return CollectionWithPagingInfo.asPaged(paging, groups, pagingResult.hasMoreItems(), totalItems);
+        return groups;
     }
 
-    private void validateZonesParam(List<String> zonesParam)
+    private GroupsFilter getGroupsFilterFromQueryParameters(Query queryParameters)
     {
-        if (zonesParam.size() > MAX_ZONES)
+        GroupsFilter.GroupsFilterBuilder groupsFilterBuilder = GroupsFilter.builder();
+
+        if (queryParameters != null)
         {
-            throw new IllegalArgumentException("A maximum of " + MAX_ZONES + " zones may be specified.");
+            GroupsQueryWalker propertyWalker = new GroupsQueryWalker();
+            QueryHelper.walk(queryParameters, propertyWalker);
+
+            groupsFilterBuilder
+                    .withIsRoot(
+                            propertyWalker.getIsRoot())
+                    .withZoneFilter(
+                            getStringFilterFromList(propertyWalker.getZones(), ZONE, MAX_ZONES))
+                    .withDisplayNameFilter(
+                            getStringFilterFromList(propertyWalker.getDisplayNames(), DISPLAY_NAME, MAX_DISPLAY_NAMES));
         }
-        else if (zonesParam.isEmpty())
+        return groupsFilterBuilder.build();
+    }
+    
+    private String getStringFilterFromList(List<String> listParam, String paramName, int maxItems)
+    {
+        String filter = null;
+        if (listParam != null)
         {
-            throw new IllegalArgumentException("Zones filter list cannot be empty.");
+            validateListParam(listParam, paramName, maxItems);
+            filter = listParam.get(0);
         }
-        // Validate each zone name
-        zonesParam.forEach(zone -> {
-            if (zone.isEmpty())
-            {
-                throw new IllegalArgumentException("Zone name cannot be empty (i.e. '')");
-            }
-        });
+        return filter;
     }
 
-    private void validateDisplayNamesParam(List<String> displayNamesParam)
+    private void validateListParam(List<String> listParam, String paramName, int maxItems)
     {
-        if (displayNamesParam.size() > MAX_DISPLAY_NAMES)
+        if (listParam.size() > maxItems)
         {
-            throw new IllegalArgumentException("A maximum of " + MAX_DISPLAY_NAMES + " displayNames may be specified.");
+            throw new IllegalArgumentException("A maximum of " + maxItems + " " + paramName + "s may be specified.");
         }
-        else if (displayNamesParam.isEmpty())
+        else if (listParam.isEmpty())
         {
-            throw new IllegalArgumentException("DisplayNames filter list cannot be empty.");
+            throw new IllegalArgumentException(StringUtils.capitalize(paramName) + "s filter list cannot be empty.");
         }
-
-        displayNamesParam.forEach(groupName -> {
-            if (groupName.isEmpty())
-            {
-                throw new IllegalArgumentException("DisplayName cannot be empty (i.e. '')");
-            }
-        });
+        
+        listParam
+                .stream()
+                .filter(String::isEmpty)
+                .findAny()
+                .ifPresent(displayName -> {
+                    throw new IllegalArgumentException(StringUtils.capitalize(paramName) + " cannot be empty (i.e. '')");
+                });
     }
 
     @Override
@@ -317,7 +311,7 @@ public class GroupsImpl implements Groups
             List<String> zonesParam = propertyWalker.getZones();
             if (zonesParam != null)
             {
-                validateZonesParam(zonesParam);
+                validateListParam(zonesParam, ZONE, MAX_ZONES);
                 zoneFilter = zonesParam.get(0);
             }
         }
@@ -361,9 +355,12 @@ public class GroupsImpl implements Groups
         return CollectionWithPagingInfo.asPaged(paging, groups, pagingResult.hasMoreItems(), totalItems);
     }
 
-    private PagingResults<AuthorityInfo> getAuthoritiesInfo(AuthorityType authorityType, Boolean isRootParam, String zoneFilter, String groupNamesFilter, Set<String> rootAuthorities, 
+    private PagingResults<AuthorityInfo> getAuthoritiesInfo(AuthorityType authorityType, GroupsFilter groupsFilter, Set<String> rootAuthorities, 
                                                             Pair<String, Boolean> sortProp, Paging paging)
     {
+        Boolean isRootParam = groupsFilter.getIsRoot();
+        String zoneFilter = groupsFilter.getZoneFilter();
+        String displayNameFilter = groupsFilter.getDisplayNameFilter();
         PagingResults<AuthorityInfo> pagingResult;
 
         if (isRootParam != null)
@@ -377,7 +374,7 @@ public class GroupsImpl implements Groups
                 List<AuthorityInfo> authorities = rootAuthorities.stream().
                         map(this::getAuthorityInfo).
                         filter(auth -> zonePredicate(auth.getAuthorityName(), zoneFilter)).
-                        filter(auth -> displayNamePredicate(auth.getAuthorityDisplayName(), groupNamesFilter)).
+                        filter(auth -> displayNamePredicate(auth.getAuthorityDisplayName(), displayNameFilter)).
                         collect(Collectors.toList());
                 groupList = new ArrayList<>(rootAuthorities.size());
                 groupList.addAll(authorities);
@@ -395,7 +392,7 @@ public class GroupsImpl implements Groups
                 // Get authorities using canned query but without using
                 // the requested paginating now because we need to filter out
                 // the root authorities.
-                PagingResults<AuthorityInfo> nonPagingResult = authorityService.getAuthoritiesInfo(authorityType, zoneFilter, groupNamesFilter, sortProp.getFirst(), sortProp.getSecond(),
+                PagingResults<AuthorityInfo> nonPagingResult = authorityService.getAuthoritiesInfo(authorityType, zoneFilter, displayNameFilter, sortProp.getFirst(), sortProp.getSecond(),
                         pagingNoMaxItems);
 
                 // Post process filtering - this should be moved to service
@@ -423,7 +420,7 @@ public class GroupsImpl implements Groups
             PagingRequest pagingRequest = Util.getPagingRequest(paging);
 
             // Get authorities using canned query.
-            pagingResult = authorityService.getAuthoritiesInfo(authorityType, zoneFilter, groupNamesFilter, sortProp.getFirst(), sortProp.getSecond(), pagingRequest);
+            pagingResult = authorityService.getAuthoritiesInfo(authorityType, zoneFilter, displayNameFilter, sortProp.getFirst(), sortProp.getSecond(), pagingRequest);
         }
         return pagingResult;
     }
@@ -1126,5 +1123,71 @@ public class GroupsImpl implements Groups
         {
             return displayNames;
         }
+    }
+}
+
+class GroupsFilter
+{
+    private Boolean isRoot;
+    private String zoneFilter;
+    private String displayNameFilter;
+    
+    private GroupsFilter()
+    {
+    }
+    
+    public static GroupsFilterBuilder builder()
+    {
+        return new GroupsFilterBuilder();
+    }
+
+    public Boolean getIsRoot()
+    {
+        return isRoot;
+    }
+    
+    public String getZoneFilter()
+    {
+        return zoneFilter;
+    }
+
+    public String getDisplayNameFilter()
+    {
+        return displayNameFilter;
+    }
+
+    public static class GroupsFilterBuilder
+    {
+        private Boolean isRoot;
+        private String zoneFilter;
+        private String displayNameFilter;
+
+        public GroupsFilterBuilder withIsRoot(Boolean isRoot)
+        {
+            this.isRoot = isRoot;
+            return this;
+        }
+
+        public GroupsFilterBuilder withZoneFilter(String zoneFilter)
+        {
+            this.zoneFilter = zoneFilter;
+            return this;
+        }
+
+        public GroupsFilterBuilder withDisplayNameFilter(String displayNameFilter)
+        {
+            this.displayNameFilter = displayNameFilter;
+            return this;
+        }
+
+        public GroupsFilter build()
+        {
+            GroupsFilter groupsFilter = new GroupsFilter();
+            groupsFilter.isRoot = this.isRoot;
+            groupsFilter.zoneFilter = this.zoneFilter;
+            groupsFilter.displayNameFilter = this.displayNameFilter;
+            return groupsFilter;
+        }
+
     }
 }

--- a/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
@@ -1858,7 +1858,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         return subGroup;
     }
 
-    private void testGetGroupsWithDisplayNameFilter() throws Exception {
+    private void testGetGroupsWithDisplayNameFilter() throws Exception 
+    {
         shouldFilterGroupByDisplayName();
         shouldFilterGroupByDisplayNameWhenNameNotExist();
         shouldFilterGroupByDisplayNameAndZone();
@@ -1868,7 +1869,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         shouldReturnBadRequestErrorWhenDisplayNameIsEmpty();
     }
 
-    private void shouldFilterGroupByDisplayName() throws Exception {
+    private void shouldFilterGroupByDisplayName() throws Exception 
+    {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
         Map<String, String> otherParams = new HashMap<>();
         otherParams.put("where", "(displayName in ('A Group'))");
@@ -1880,7 +1882,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         assertEquals("A Group", groups.get(0).getDisplayName());
     }
 
-    private void shouldFilterGroupByDisplayNameWhenNameNotExist() throws Exception {
+    private void shouldFilterGroupByDisplayNameWhenNameNotExist() throws Exception 
+    {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
         Map<String, String> otherParams = new HashMap<>();
         otherParams.put("where", "(displayName in ('AGroupName'))");
@@ -1891,7 +1894,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         assertTrue(groups.isEmpty());
     }
 
-    private void shouldFilterGroupByDisplayNameAndZone() throws Exception {
+    private void shouldFilterGroupByDisplayNameAndZone() throws Exception 
+    {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
         Map<String, String> otherParams = new HashMap<>();
         addOrderBy(otherParams, org.alfresco.rest.api.Groups.PARAM_DISPLAY_NAME, true);
@@ -1906,7 +1910,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         assertEquals("A Group", groups.get(0).getDisplayName());
     }
 
-    private void shouldFilterGroupByDisplayNameWhenGroupIsRoot() throws Exception {
+    private void shouldFilterGroupByDisplayNameWhenGroupIsRoot() throws Exception 
+    {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
         Map<String, String> otherParams = new HashMap<>();
         otherParams.put("where", "(isRoot=true AND displayName in ('Root Group'))");
@@ -1918,7 +1923,8 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         assertEquals("Root Group", groups.get(0).getDisplayName());
     }
 
-    private void shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot() throws Exception {
+    private void shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot() throws Exception 
+    {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
         Map<String, String> otherParams = new HashMap<>();
         otherParams.put("include", org.alfresco.rest.api.Groups.PARAM_INCLUDE_ZONES);

--- a/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
@@ -1859,14 +1859,16 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
     }
 
     private void testGetGroupsWithDisplayNameFilter() throws Exception 
-    {
+    { 
         shouldFilterGroupByDisplayName();
         shouldFilterGroupByDisplayNameWhenNameNotExist();
         shouldFilterGroupByDisplayNameAndZone();
         shouldFilterGroupByDisplayNameWhenGroupIsRoot();
+        shouldFilterGroupByDisplayNameWhenIsRootIsFalse();
         shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot();
         shouldReturnBadRequestErrorWhenTooManyDisplayNames();
         shouldReturnBadRequestErrorWhenDisplayNameIsEmpty();
+        shouldNotAllowWildcards();
     }
 
     private void shouldFilterGroupByDisplayName() throws Exception 
@@ -1877,6 +1879,13 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
 
         ListResponse<Group> response = getGroups(paging, otherParams);
         List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertEquals("A Group", groups.get(0).getDisplayName());
+
+        otherParams.put("where", "(displayName in ('a group'))");
+        response = getGroups(paging, otherParams);
+        response.getList();
 
         assertEquals(1, groups.size());
         assertEquals("A Group", groups.get(0).getDisplayName());
@@ -1923,6 +1932,19 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         assertEquals("Root Group", groups.get(0).getDisplayName());
     }
 
+    private void shouldFilterGroupByDisplayNameWhenIsRootIsFalse() throws Exception
+    {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where", "(isRoot=False AND displayName in ('A Group'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertEquals("A Group", groups.get(0).getDisplayName());
+    }
+
     private void shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot() throws Exception 
     {
         Paging paging = getPaging(0, Integer.MAX_VALUE);
@@ -1957,5 +1979,71 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
     
         otherParams.put("where","(displayName in (''))");
         getGroups(paging, otherParams, "Incorrect response",400); 
+    }
+    
+    private void shouldNotAllowWildcards() throws Exception
+    {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        
+        otherParams.put("where", "(displayName in ('*'))");
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(0, groups.size());
+        
+        otherParams.put("where", "(isRoot=true AND displayName in ('*'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(displayName in ('A*'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(isRoot=true AND displayName in ('A*'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(displayName in ('*roup'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+        
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(isRoot=true AND displayName in ('*roup'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+
+        assertEquals(0, groups.size());
+        
+        otherParams.put("where", "(displayName in ('Root ?ROUP'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+        
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(isRoot=true AND displayName in ('Root ?ROUP'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+        
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(displayName in ('Group'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+        
+        assertEquals(0, groups.size());
+
+        otherParams.put("where", "(isRoot=true AND displayName in ('Group'))");
+        response = getGroups(paging, otherParams);
+        groups = response.getList();
+        
+        assertEquals(0, groups.size());
     }
 }

--- a/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
+++ b/src/test/java/org/alfresco/rest/api/tests/GroupsTest.java
@@ -115,6 +115,7 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
             testGetGroupsByIsRoot(true);
             testGetGroupsByIsRoot(false);
             testGetGroupsWithZoneFilter();
+            testGetGroupsWithDisplayNameFilter();
         }
         finally
         {
@@ -1855,5 +1856,100 @@ public class GroupsTest extends AbstractSingleNetworkSiteTest
         subGroup.setParentIds(subGroupParents);
 
         return subGroup;
+    }
+
+    private void testGetGroupsWithDisplayNameFilter() throws Exception {
+        shouldFilterGroupByDisplayName();
+        shouldFilterGroupByDisplayNameWhenNameNotExist();
+        shouldFilterGroupByDisplayNameAndZone();
+        shouldFilterGroupByDisplayNameWhenGroupIsRoot();
+        shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot();
+        shouldReturnBadRequestErrorWhenTooManyDisplayNames();
+        shouldReturnBadRequestErrorWhenDisplayNameIsEmpty();
+    }
+
+    private void shouldFilterGroupByDisplayName() throws Exception {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where", "(displayName in ('A Group'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertEquals("A Group", groups.get(0).getDisplayName());
+    }
+
+    private void shouldFilterGroupByDisplayNameWhenNameNotExist() throws Exception {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where", "(displayName in ('AGroupName'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertTrue(groups.isEmpty());
+    }
+
+    private void shouldFilterGroupByDisplayNameAndZone() throws Exception {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        addOrderBy(otherParams, org.alfresco.rest.api.Groups.PARAM_DISPLAY_NAME, true);
+        otherParams.put("include", org.alfresco.rest.api.Groups.PARAM_INCLUDE_ZONES);
+        otherParams.put("where", "(zones in ('APITEST.MYZONE') AND displayName in ('A Group'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertTrue(groups.get(0).getZones().contains("APITEST.MYZONE"));
+        assertEquals("A Group", groups.get(0).getDisplayName());
+    }
+
+    private void shouldFilterGroupByDisplayNameWhenGroupIsRoot() throws Exception {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where", "(isRoot=true AND displayName in ('Root Group'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertEquals("Root Group", groups.get(0).getDisplayName());
+    }
+
+    private void shouldFilterGroupByDisplayNameAndZoneWhenGroupIsRoot() throws Exception {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("include", org.alfresco.rest.api.Groups.PARAM_INCLUDE_ZONES);
+        otherParams.put("where", "(isRoot=true AND zones in ('APITEST.MYZONE') AND displayName in ('Root Group'))");
+
+        ListResponse<Group> response = getGroups(paging, otherParams);
+        List<Group> groups = response.getList();
+
+        assertEquals(1, groups.size());
+        assertTrue(groups.get(0).getZones().contains("APP.DEFAULT"));
+        assertEquals("Root Group", groups.get(0).getDisplayName());
+    }
+
+    private void shouldReturnBadRequestErrorWhenTooManyDisplayNames() throws Exception
+    {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where", "(displayName in ('Group A', 'Group B'))");
+
+        getGroups(paging, otherParams, "Incorrect response", 400);
+    }
+
+    private void shouldReturnBadRequestErrorWhenDisplayNameIsEmpty() throws Exception 
+    {
+        Paging paging = getPaging(0, Integer.MAX_VALUE);
+        Map<String, String> otherParams = new HashMap<>();
+        otherParams.put("where","(displayName in ())");
+    
+        getGroups(paging, otherParams, "Incorrect response",400);
+    
+        otherParams.put("where","(displayName in (''))");
+        getGroups(paging, otherParams, "Incorrect response",400); 
     }
 }


### PR DESCRIPTION
Add tha ability to filter groups by displayName when using /groups endpoint and the "where"query parameter. 

e.g `where=(displayName in ('AGroupName'))`

At the moment it is possible specify only 1 group name in the list of displayNames ( the same as for zones).

I decided to avoid to use the pre-existing filter present in  authorityService.getAuthoritiesInfo() for the following motivation:

- I tested it and it allows wildcards

-  It filters by groupName instead of groupDisplayName 