### PR TITLE
MNT-21702 : Kerberos SSO fallback mechanism for WebDAV

### DIFF
--- a/src/main/java/org/alfresco/repo/webdav/auth/BaseKerberosAuthenticationFilter.java
+++ b/src/main/java/org/alfresco/repo/webdav/auth/BaseKerberosAuthenticationFilter.java
@@ -366,7 +366,22 @@ public abstract class BaseKerberosAuthenticationFilter extends BaseSSOAuthentica
             }
             
             // Send back a request for SPNEGO authentication
-            logonStartAgain(context, req, resp, true);
+
+            // MNT-21702 fixing Kerberos SSO fallback machanism for WebDAV
+            if (req.getRequestURL().toString().contains("webdav"))
+            {
+                if ( getLogger().isDebugEnabled()) {
+                    getLogger().debug("WebDAV request, fallback");
+                }
+                logonStartAgain(context, req, resp, false);
+            }
+            else
+            {
+                if ( getLogger().isDebugEnabled()) {
+                    getLogger().debug("Non-WebDAV request, don't fallback");
+                }
+                logonStartAgain(context, req, resp, true);
+            }
 
             return false;
         }


### PR DESCRIPTION
   Reinstated 'part' of the reverted code change originally made in MNT-16931 to handle fallback correctly for WebDAV in a kerberos environment.