### PR TITLE
MNT-20709 - small change to the admin template for handling epoch dates a little better (with timezones)

### DIFF
--- a/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/admin-template.ftl
+++ b/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/admin-template.ftl
@@ -689,7 +689,7 @@ Admin.addEventListener(window, 'load', function() {
    <#switch type>
       <#case "java.util.Date">
          <#if value?has_content>
-            <#return value?datetime>
+            <#return value?datetime?string.full>
          <#else>
             <#return value>
          </#if>


### PR DESCRIPTION
This is a small change to use a freemarker built-in to display dates in the JVM timezone so they are easier to understand.