### PR TITLE
It's now possible via configuration to obtain performance stats from API calls

### DIFF
--- a/src/main/resources/alfresco/project-remote-api.properties
+++ b/src/main/resources/alfresco/project-remote-api.properties
@@ -24,5 +24,6 @@
 alfresco.restApi.basicAuthScheme=false
 # REPO-4388 allow CORS headers in transaction response
 webscripts.transaction.preserveHeadersPattern=Access-Control-.*
+
 # REPO-5371 enable stats header in API response (only search atm)
 # webscripts.stats.enabled=true

--- a/src/main/resources/alfresco/project-remote-api.properties
+++ b/src/main/resources/alfresco/project-remote-api.properties
@@ -24,3 +24,5 @@
 alfresco.restApi.basicAuthScheme=false
 # REPO-4388 allow CORS headers in transaction response
 webscripts.transaction.preserveHeadersPattern=Access-Control-.*
+# REPO-5371 enable stats header in API response (only search atm)
+# webscripts.stats.enabled=true

--- a/src/main/resources/alfresco/public-rest-context.xml
+++ b/src/main/resources/alfresco/public-rest-context.xml
@@ -1010,6 +1010,7 @@
         <property name="helper" ref="webscriptHelper" />
         <property name="resultMapper" ref="searchapiResultMapper" />
         <property name="searchMapper" ref="searchapiSearchMapper" />
+        <property name="statsEnabled" value="${webscripts.stats.enabled}" />
     </bean>
     
     <bean id="webscript.org.alfresco.api.SearchSQLApiWebscript.post"


### PR DESCRIPTION
This PR implements a simple functionality on the /search endpoint. It is controlled by a flag defined via properties.